### PR TITLE
[CAN-31/feat] 장바구니 요소 드래그 드롭 기능 구현

### DIFF
--- a/src/components/todoCalendar/Calendar.tsx
+++ b/src/components/todoCalendar/Calendar.tsx
@@ -40,6 +40,7 @@ type Props = {
   selectedDate: Date;
   onDateChange: (date: Date) => void;
   calendarRef: React.RefObject<FullCalendar>;
+  onDropTodo: (date: string, todoId: number) => void;
 };
 
 /**
@@ -50,6 +51,7 @@ export default function Calendar({
   selectedDate,
   onDateChange,
   calendarRef,
+  onDropTodo,
 }: Props) {
   /**
    * 각 날짜 칸을 클릭을 처리하는 핸들러
@@ -123,7 +125,7 @@ export default function Calendar({
       events={todos.map((event) => ({
         ...event,
         id: event.id.toString(),
-        className: event.goal.color,
+        className: event.goal?.color || 'bg-slate950',
       }))}
       eventBorderColor="transparent"
       eventDisplay="block"
@@ -135,6 +137,14 @@ export default function Calendar({
       contentHeight="100%"
       dayCellContent={(info) => renderDayCellContent(info, selectedDate)}
       dayCellDidMount={updateCellSize}
+      droppable
+      eventReceive={(info) => {
+        const todoId = Number(info.event.id);
+        const date = info.event.startStr;
+
+        onDropTodo(date, todoId);
+        info.event.remove();
+      }}
     />
   );
 }

--- a/src/components/todoCalendar/Calendar.tsx
+++ b/src/components/todoCalendar/Calendar.tsx
@@ -100,7 +100,7 @@ export default function Calendar({
    * 사이드 바가 접히거나 펼쳐지면 캘린더 크기 재조정
    */
   useEffect(() => {
-    const sidebar = document.querySelector('header'); // 사이드바 선택
+    const sidebar = document.querySelector('nav'); // 사이드바 선택
     if (!sidebar) return undefined;
 
     const observer = new MutationObserver(() => {

--- a/src/components/todoCalendar/TodoBasket.tsx
+++ b/src/components/todoCalendar/TodoBasket.tsx
@@ -53,7 +53,7 @@ export default function TodoBasket({
         {basketList.map((todo) => (
           <div
             key={todo.id}
-            className="draggable-todo flex w-[150px] items-center justify-between gap-3 rounded-lg border p-3 shadow-sm"
+            className="draggable-todo flex w-[150px] cursor-grab items-center justify-between gap-3 rounded-lg border p-3 shadow-sm active:cursor-grabbing"
             draggable
             data-id={todo.id}
           >

--- a/src/components/todoCalendar/TodoBasket.tsx
+++ b/src/components/todoCalendar/TodoBasket.tsx
@@ -1,5 +1,9 @@
+import { Draggable } from '@fullcalendar/interaction';
+import { useEffect, useRef } from 'react';
+import { Goal } from '@/types/todos';
+
 type Props = {
-  basketList: { id: number; title: string }[];
+  basketList: { id: number; title: string; goal: Goal | null }[];
   onDeleteBasketTodo: (id: number) => void;
   onDeleteAllBasket: () => void;
 };
@@ -9,6 +13,21 @@ export default function TodoBasket({
   onDeleteBasketTodo,
   onDeleteAllBasket,
 }: Props) {
+  const basketRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (basketRef.current) {
+      const draggable = new Draggable(basketRef.current, {
+        itemSelector: '.draggable-todo',
+        eventData: (eventEl) => ({
+          id: eventEl.getAttribute('data-id'),
+        }),
+      });
+
+      return () => draggable.destroy();
+    }
+    return undefined;
+  }, []);
   return (
     <div className="w-full bg-white p-3">
       <div className="mb-3 flex items-center gap-4">
@@ -27,11 +46,16 @@ export default function TodoBasket({
           모두 삭제
         </button>
       </div>
-      <div className="flex max-h-40 flex-wrap gap-3 overflow-y-auto">
+      <div
+        ref={basketRef}
+        className="flex max-h-40 flex-wrap gap-3 overflow-y-auto"
+      >
         {basketList.map((todo) => (
           <div
             key={todo.id}
-            className="flex w-[150px] items-center justify-between gap-3 rounded-lg border p-3 shadow-sm"
+            className="draggable-todo flex w-[150px] items-center justify-between gap-3 rounded-lg border p-3 shadow-sm"
+            draggable
+            data-id={todo.id}
           >
             <span className="truncate">{todo.title}</span>
             <button

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import Calendar from './Calendar';
 import CalendarHeader from './CalendarHeader';
 import TodoList from './TodoList';
-import { TodoType } from '@/types/todos';
+import { BasketType, TodoType } from '@/types/todos';
 import Loading from '../common/Loading';
 import TodoBasket from './TodoBasket';
 
@@ -223,28 +223,28 @@ const initialTodos = [
 ];
 
 const initialBasketList = [
-  { id: 101, title: '코딩강의 듣기' },
-  { id: 102, title: '할 일이 길어지면 어쩌구 저쩌구' },
-  { id: 103, title: '할 일 52' },
-  { id: 104, title: '할 일 62' },
-  { id: 105, title: '할 일 72' },
-  { id: 106, title: '할 일 82' },
-  { id: 107, title: '할 일 92' },
-  { id: 108, title: '할 일 102' },
-  { id: 109, title: '할 일 112' },
-  { id: 110, title: '할 일 122' },
-  { id: 111, title: '할 일 132' },
-  { id: 112, title: '할 일 142' },
-  { id: 113, title: '할 일 152' },
-  { id: 114, title: '할 일 162' },
-  { id: 115, title: '할 일 172' },
-  { id: 116, title: '할 일 182' },
+  { id: 101, title: '코딩강의 듣기', goal: null },
+  { id: 102, title: '할 일이 길어지면 어쩌구 저쩌구', goal: null },
+  { id: 103, title: '할 일 52', goal: null },
+  { id: 104, title: '할 일 62', goal: null },
+  { id: 105, title: '할 일 72', goal: null },
+  { id: 106, title: '할 일 82', goal: null },
+  { id: 107, title: '할 일 92', goal: null },
+  { id: 108, title: '할 일 102', goal: null },
+  { id: 109, title: '할 일 112', goal: null },
+  { id: 110, title: '할 일 122', goal: null },
+  { id: 111, title: '할 일 132', goal: null },
+  { id: 112, title: '할 일 142', goal: null },
+  { id: 113, title: '할 일 152', goal: null },
+  { id: 114, title: '할 일 162', goal: null },
+  { id: 115, title: '할 일 172', goal: null },
+  { id: 116, title: '할 일 182', goal: null },
 ];
 
 export default function TodoCalendar() {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [todos, setTodos] = useState<TodoType[]>(initialTodos);
-  const [basketList, setBasketList] = useState(initialBasketList);
+  const [basketList, setBasketList] = useState<BasketType[]>(initialBasketList);
   const [isCalendarReady, setIsCalendarReady] = useState<boolean>(false);
   const [calendarHeight, setCalendarHeight] = useState<number>(0);
   const calendarRef = useRef<FullCalendar>(null);
@@ -296,6 +296,26 @@ export default function TodoCalendar() {
     setBasketList([]);
   };
 
+  /**
+   * 드랍 시 todo에 추가 & 장바구니에서 제거
+   * @returns
+   */
+  const handleDropTodo = (date: string, todoId: number) => {
+    const draggedTodo = basketList.find((todo) => todo.id === todoId);
+    if (!draggedTodo) return;
+
+    const newTodo: TodoType = {
+      id: todoId,
+      title: draggedTodo.title,
+      date,
+      goal: draggedTodo.goal || null,
+      done: false,
+    };
+
+    setTodos((prev) => [...prev, newTodo]);
+    setBasketList((prev) => prev.filter((todo) => todo.id !== todoId));
+  };
+
   useEffect(() => {
     if (calendarRef.current) {
       const calendarApi = calendarRef.current.getApi();
@@ -334,6 +354,7 @@ export default function TodoCalendar() {
             selectedDate={selectedDate}
             onDateChange={setSelectedDate}
             calendarRef={calendarRef}
+            onDropTodo={handleDropTodo}
           />
         </div>
         {isCalendarReady ? (

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -238,7 +238,15 @@ const initialBasketList = [
   { id: 113, title: '할 일 152', goal: null },
   { id: 114, title: '할 일 162', goal: null },
   { id: 115, title: '할 일 172', goal: null },
-  { id: 116, title: '할 일 182', goal: null },
+  {
+    id: 116,
+    title: '할 일 182',
+    goal: {
+      id: 1,
+      title: '강의 듣기',
+      color: 'bg-red-500',
+    },
+  },
 ];
 
 export default function TodoCalendar() {
@@ -298,7 +306,6 @@ export default function TodoCalendar() {
 
   /**
    * 드랍 시 todo에 추가 & 장바구니에서 제거
-   * @returns
    */
   const handleDropTodo = (date: string, todoId: number) => {
     const draggedTodo = basketList.find((todo) => todo.id === todoId);

--- a/src/components/todoCalendar/TodoListItem.tsx
+++ b/src/components/todoCalendar/TodoListItem.tsx
@@ -75,9 +75,11 @@ export default function TodoListItem({
               onClick={() => onToggleTodo(todo.id)}
               className="flex-grow cursor-pointer overflow-hidden"
             >
-              <p className="truncate text-sm text-gray-400">
-                {todo.goal.title}
-              </p>
+              {todo.goal && (
+                <p className="truncate text-sm text-gray-400">
+                  {todo.goal.title}
+                </p>
+              )}
               <p
                 className={cn(
                   'truncate',

--- a/src/types/todos.d.ts
+++ b/src/types/todos.d.ts
@@ -8,6 +8,12 @@ export interface TodoType {
   id: number;
   title: string;
   date: string;
-  goal: Goals;
+  goal: Goal | null;
   done: boolean;
+}
+
+export interface BasketType {
+  id: number;
+  title: string;
+  goal: Goal | null;
 }


### PR DESCRIPTION
<!-- title: "[CAN-/커밋 컨벤션의 타입] 제목" -->
<!-- 예시 [CAN-123/feat] admin page 추가 / [CAN-123/refactor] 테스트 후 접근성 개선 -->

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝
- 장바구니 요소 캘린더로 드래그 드롭 가능하게 fullCalendar의 Draggable 사용
- 할 일의 목표 null 가능하게 타입 선언 & null일 경우 default color로 임시 색 넣음

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`
