### PR TITLE
[CAN-36/style] 캘린더 디자인 적용

### DIFF
--- a/src/components/todoCalendar/Calendar.tsx
+++ b/src/components/todoCalendar/Calendar.tsx
@@ -1,20 +1,34 @@
-import { useRef } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import { TodoType } from '@/types/todos';
 import CalendarBody from './CalendarBody';
 import CalendarHeader from './CalendarHeader';
 
-type Props = {
+interface Props {
   todos: TodoType[];
   selectedDate: Date;
+  calendarRef: React.RefObject<FullCalendar>;
   onDateChange: (date: Date) => void;
   onDropTodo: (date: string, todoId: number) => void;
-};
+}
 
-function Calendar({ todos, selectedDate, onDateChange, onDropTodo }: Props) {
-  const calendarRef = useRef<FullCalendar>(null);
+/**
+ * 캘린더 전체 컴포넌트
+ * 캘린더 헤더 + 바디
+ * @param todos 할 일 전체
+ * @param selectedDate 선택된 날짜
+ * @param calendarRef 캘린더의 ref
+ * @param onDateChange 선택 날짜 변경 함수
+ * @param onDropTodo 장바구니에서 드래그&드롭 한 요소 드롭 적용 함수
+ */
+function Calendar({
+  todos,
+  selectedDate,
+  calendarRef,
+  onDateChange,
+  onDropTodo,
+}: Props) {
   return (
-    <div className="w-[840px]">
+    <div>
       <CalendarHeader calendarRef={calendarRef} onDateChange={onDateChange} />
       <CalendarBody
         todos={todos}

--- a/src/components/todoCalendar/Calendar.tsx
+++ b/src/components/todoCalendar/Calendar.tsx
@@ -1,150 +1,30 @@
+import { useRef } from 'react';
 import FullCalendar from '@fullcalendar/react';
-import dayGridPlugin from '@fullcalendar/daygrid';
-import interactionPlugin from '@fullcalendar/interaction';
-import timeGridPlugin from '@fullcalendar/timegrid';
-import { DayCellContentArg, EventClickArg } from '@fullcalendar/core';
-import '@/styles/calendar.css';
-import { useCallback, useEffect } from 'react';
-import cn from '@/utils/cn';
 import { TodoType } from '@/types/todos';
-
-/**
- * 각 날짜 숫자를 커스텀한 UI
- *
- * @param info 각 날짜 정보
- * @param selectedDate 선택된 날짜
- */
-const renderDayCellContent = (info: DayCellContentArg, selectedDate: Date) => {
-  const isSelectedDate =
-    selectedDate.toDateString() === info.date.toDateString();
-  const dateText = info.date.getDate().toString();
-
-  return (
-    <div className="flex h-full items-center justify-center">
-      <span
-        className={cn(
-          'flex items-center justify-center',
-          'h-6 w-6',
-          'rounded-full',
-          isSelectedDate && 'bg-purple-500 text-white',
-        )}
-      >
-        {dateText}
-      </span>
-    </div>
-  );
-};
+import CalendarBody from './CalendarBody';
+import CalendarHeader from './CalendarHeader';
 
 type Props = {
   todos: TodoType[];
   selectedDate: Date;
   onDateChange: (date: Date) => void;
-  calendarRef: React.RefObject<FullCalendar>;
   onDropTodo: (date: string, todoId: number) => void;
 };
 
-/**
- * 달력 컴포넌트
- */
-export default function Calendar({
-  todos,
-  selectedDate,
-  onDateChange,
-  calendarRef,
-  onDropTodo,
-}: Props) {
-  /**
-   * 각 날짜 칸을 클릭을 처리하는 핸들러
-   */
-  const handleDateClick = useCallback(
-    (info: { date: Date }) => {
-      onDateChange(new Date(info.date));
-    },
-    [onDateChange],
-  );
-
-  /**
-   * 이벤트를 클릭해도 선택 날짜 변경
-   */
-  const handleEventClick = (info: EventClickArg) => {
-    if (info.event.start) {
-      onDateChange(new Date(info.event.start)); // 선택된 날짜 변경
-    }
-  };
-  /**
-   * 날짜 셀 크기 업데이트
-   */
-  const updateCellSize = () => {
-    const cell = document.querySelector('.fc-daygrid-day');
-    if (cell) {
-      const width = cell.clientWidth;
-      document.querySelectorAll('.fc-daygrid-day').forEach((el) => {
-        const cellElement = el as HTMLElement;
-        if (width < 88) {
-          cellElement.style.height = `${width}px`;
-        }
-        cellElement.style.minHeight = `${width}px`;
-        cellElement.style.height = '88px';
-      });
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener('resize', updateCellSize);
-    updateCellSize(); // 초기 설정
-
-    return () => window.removeEventListener('resize', updateCellSize);
-  }, []);
-
-  /**
-   * 사이드 바가 접히거나 펼쳐지면 캘린더 크기 재조정
-   */
-  useEffect(() => {
-    const sidebar = document.querySelector('nav'); // 사이드바 선택
-    if (!sidebar) return undefined;
-
-    const observer = new MutationObserver(() => {
-      setTimeout(() => {
-        window.dispatchEvent(new Event('resize'));
-      }, 200);
-    });
-
-    observer.observe(sidebar, {
-      attributes: true,
-      attributeFilter: ['class'],
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
+function Calendar({ todos, selectedDate, onDateChange, onDropTodo }: Props) {
+  const calendarRef = useRef<FullCalendar>(null);
   return (
-    <FullCalendar
-      ref={calendarRef}
-      plugins={[dayGridPlugin, interactionPlugin, timeGridPlugin]}
-      initialView="dayGridMonth"
-      events={todos.map((event) => ({
-        ...event,
-        id: event.id.toString(),
-        className: event.goal?.color || 'bg-slate950',
-      }))}
-      eventBorderColor="transparent"
-      eventDisplay="block"
-      dateClick={handleDateClick}
-      eventClick={handleEventClick}
-      locale="kr"
-      headerToolbar={false}
-      height="auto"
-      contentHeight="100%"
-      dayCellContent={(info) => renderDayCellContent(info, selectedDate)}
-      dayCellDidMount={updateCellSize}
-      droppable
-      eventReceive={(info) => {
-        const todoId = Number(info.event.id);
-        const date = info.event.startStr;
-
-        onDropTodo(date, todoId);
-        info.event.remove();
-      }}
-    />
+    <div className="w-[840px]">
+      <CalendarHeader calendarRef={calendarRef} onDateChange={onDateChange} />
+      <CalendarBody
+        todos={todos}
+        selectedDate={selectedDate}
+        onDateChange={onDateChange}
+        calendarRef={calendarRef}
+        onDropTodo={onDropTodo}
+      />
+    </div>
   );
 }
+
+export default Calendar;

--- a/src/components/todoCalendar/Calendar.tsx
+++ b/src/components/todoCalendar/Calendar.tsx
@@ -1,10 +1,10 @@
 import FullCalendar from '@fullcalendar/react';
-import { TodoType } from '@/types/todos';
+import { Todo } from '@/types/todos';
 import CalendarBody from './CalendarBody';
 import CalendarHeader from './CalendarHeader';
 
 interface Props {
-  todos: TodoType[];
+  todos: Todo[];
   selectedDate: Date;
   calendarRef: React.RefObject<FullCalendar>;
   onDateChange: (date: Date) => void;
@@ -20,7 +20,7 @@ interface Props {
  * @param onDateChange 선택 날짜 변경 함수
  * @param onDropTodo 장바구니에서 드래그&드롭 한 요소 드롭 적용 함수
  */
-function Calendar({
+export default function Calendar({
   todos,
   selectedDate,
   calendarRef,
@@ -40,5 +40,3 @@ function Calendar({
     </div>
   );
 }
-
-export default Calendar;

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -80,21 +80,51 @@ export default function CalendarBody({
   /**
    * 날짜 셀 크기 업데이트
    */
-  const updateCellSize = () => {
-    const cell = document.querySelector('.fc-daygrid-day');
-    if (cell) {
-      const width = cell.clientWidth;
-      document.querySelectorAll('.fc-daygrid-day').forEach((el) => {
-        const cellElement = el as HTMLElement;
-        if (width < 118) {
-          cellElement.style.height = `${width}px`;
-          cellElement.style.minHeight = `${width}px`;
-        } else {
-          cellElement.style.height = '124px';
-          cellElement.style.minHeight = '124px';
-        }
-      });
-    }
+
+  const handleDayCellMount = (info: { el: HTMLElement }) => {
+    // 반응형에 맞춰 셀 크기 업데이트
+    const updateCellSize = () => {
+      const cell = document.querySelector('.fc-daygrid-day');
+      if (cell) {
+        const width = cell.clientWidth;
+        document.querySelectorAll('.fc-daygrid-day').forEach((el) => {
+          const cellElement = el as HTMLElement;
+          if (width < 118) {
+            cellElement.style.height = `${width}px`;
+            cellElement.style.minHeight = `${width}px`;
+          } else {
+            cellElement.style.height = '124px';
+            cellElement.style.minHeight = '124px';
+          }
+        });
+      }
+    };
+    // 숨겨진 이벤트 개수 표시
+    const updateMoreCount = () => {
+      setTimeout(() => {
+        const events = info.el.querySelectorAll('.fc-event');
+
+        // 숨겨진 이벤트 개수 계산
+        const hiddenEvents = Array.from(events).filter(
+          (e) => (e as HTMLElement).offsetHeight === 0,
+        ).length;
+
+        const moreCountEl = document.createElement('div');
+        moreCountEl.className =
+          'event-more-count absolute top-2 right-2 text-12SB text-gs500';
+        info.el.appendChild(moreCountEl);
+
+        // 숨겨진 이벤트가 있으면 텍스트 추가, 없으면 숨김
+        moreCountEl.textContent =
+          hiddenEvents > 0 ? `+ ${hiddenEvents} more` : '';
+        moreCountEl.style.opacity = hiddenEvents > 0 ? '1' : '0';
+      }, 100);
+    };
+
+    updateCellSize();
+    updateMoreCount();
+
+    window.addEventListener('resize', updateCellSize);
   };
 
   const getColorClasses = (color?: string) => {
@@ -103,13 +133,6 @@ export default function CalendarBody({
       [`bg-${color}-100 text-${color}`]: color, // 동적 색상 적용
     });
   };
-
-  useEffect(() => {
-    window.addEventListener('resize', updateCellSize);
-    updateCellSize();
-
-    return () => window.removeEventListener('resize', updateCellSize);
-  }, []);
 
   /**
    * 사이드 바가 접히거나 펼쳐지면 캘린더 크기 재조정
@@ -153,7 +176,7 @@ export default function CalendarBody({
       contentHeight="100%"
       dayCellContent={(info) => renderDayCellContent(info)}
       dayCellClassNames={(info) => getDayCellClassNames(info)}
-      dayCellDidMount={updateCellSize}
+      dayCellDidMount={handleDayCellMount}
       droppable
       eventReceive={(info) => {
         const todoId = Number(info.event.id);

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -107,7 +107,7 @@ export default function CalendarBody({
     };
     // 숨겨진 이벤트 개수 표시
     const updateMoreCount = () => {
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         const events = info.el.querySelectorAll('.fc-event');
 
         // 숨겨진 이벤트 개수 계산
@@ -140,7 +140,7 @@ export default function CalendarBody({
         } else {
           moreCountEl.style.opacity = '0';
         }
-      }, 100);
+      });
     };
 
     updateCellSize();

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -109,20 +109,39 @@ export default function CalendarBody({
           (e) => (e as HTMLElement).offsetHeight === 0,
         ).length;
 
-        const moreCountEl = document.createElement('div');
-        moreCountEl.className =
-          'event-more-count absolute top-2 right-2 text-12SB text-gs500';
-        info.el.appendChild(moreCountEl);
+        let moreCountEl = info.el.querySelector(
+          '.event-more-count',
+        ) as HTMLElement;
+        if (!moreCountEl) {
+          moreCountEl = document.createElement('div');
+          moreCountEl.className =
+            'event-more-count absolute top-2 right-2 text-12SB text-gs500';
+          info.el.appendChild(moreCountEl);
+        }
 
         // 숨겨진 이벤트가 있으면 텍스트 추가, 없으면 숨김
-        moreCountEl.textContent =
-          hiddenEvents > 0 ? `+ ${hiddenEvents} more` : '';
-        moreCountEl.style.opacity = hiddenEvents > 0 ? '1' : '0';
+        const cellWidth = info.el.clientWidth;
+        if (hiddenEvents > 0) {
+          if (cellWidth > 88) {
+            moreCountEl.textContent = `+${hiddenEvents} more`;
+          } else if (cellWidth >= 50) {
+            moreCountEl.textContent = `+${hiddenEvents}`;
+          } else {
+            moreCountEl.textContent = '';
+          }
+
+          moreCountEl.style.opacity = '1';
+        } else {
+          moreCountEl.style.opacity = '0';
+        }
       }, 100);
     };
 
     updateCellSize();
     updateMoreCount();
+
+    const observer = new ResizeObserver(updateMoreCount);
+    observer.observe(info.el);
 
     window.addEventListener('resize', updateCellSize);
   };

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -12,7 +12,6 @@ import { TodoType } from '@/types/todos';
  * 각 날짜 숫자를 커스텀한 UI
  *
  * @param info 각 날짜 정보
- * @param selectedDate 선택된 날짜
  */
 const renderDayCellContent = (info: DayCellContentArg) => {
   const dateText = info.date.getDate().toString();
@@ -24,7 +23,7 @@ const renderDayCellContent = (info: DayCellContentArg) => {
     <div
       className={cn(
         'flex items-center justify-center rounded-sm p-2',
-        'h-5 w-5',
+        'size-5',
         isToday && 'bg-slate500 text-white',
         isSunday && 'text-warn500',
       )}
@@ -34,13 +33,13 @@ const renderDayCellContent = (info: DayCellContentArg) => {
   );
 };
 
-type Props = {
+interface Props {
   todos: TodoType[];
   selectedDate: Date;
   onDateChange: (date: Date) => void;
   calendarRef: React.RefObject<FullCalendar>;
   onDropTodo: (date: string, todoId: number) => void;
-};
+}
 
 export default function CalendarBody({
   todos,
@@ -77,6 +76,7 @@ export default function CalendarBody({
       onDateChange(new Date(info.event.start)); // 선택된 날짜 변경
     }
   };
+
   /**
    * 날짜 셀 크기 업데이트
    */
@@ -86,19 +86,27 @@ export default function CalendarBody({
       const width = cell.clientWidth;
       document.querySelectorAll('.fc-daygrid-day').forEach((el) => {
         const cellElement = el as HTMLElement;
-        if (width < 120) {
+        if (width < 118) {
           cellElement.style.height = `${width}px`;
+          cellElement.style.minHeight = `${width}px`;
         } else {
-          cellElement.style.height = '120px';
+          cellElement.style.height = '124px';
+          cellElement.style.minHeight = '124px';
         }
-        cellElement.style.minHeight = `${width}px`;
       });
     }
   };
 
+  const getColorClasses = (color?: string) => {
+    return cn({
+      'bg-slate100 text-slate500': !color, // 기본 색상
+      [`bg-${color}-100 text-${color}`]: color, // 동적 색상 적용
+    });
+  };
+
   useEffect(() => {
     window.addEventListener('resize', updateCellSize);
-    updateCellSize(); // 초기 설정
+    updateCellSize();
 
     return () => window.removeEventListener('resize', updateCellSize);
   }, []);
@@ -132,7 +140,7 @@ export default function CalendarBody({
       events={todos.map((event) => ({
         ...event,
         id: event.id.toString(),
-        className: event.goal?.color || 'bg-slate950',
+        className: getColorClasses(event.goal?.color),
       }))}
       eventBorderColor="transparent"
       eventDisplay="block"

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -1,0 +1,159 @@
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import { DayCellContentArg, EventClickArg } from '@fullcalendar/core';
+import '@/styles/calendar.css';
+import { useCallback, useEffect } from 'react';
+import cn from '@/utils/cn';
+import { TodoType } from '@/types/todos';
+
+/**
+ * 각 날짜 숫자를 커스텀한 UI
+ *
+ * @param info 각 날짜 정보
+ * @param selectedDate 선택된 날짜
+ */
+const renderDayCellContent = (info: DayCellContentArg) => {
+  const dateText = info.date.getDate().toString();
+  const isToday = new Date().toDateString() === info.date.toDateString();
+  const isSunday =
+    info.view.calendar.formatDate(info.date, { weekday: 'long' }) === '일요일';
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center rounded-sm p-2',
+        'h-5 w-5',
+        isToday && 'bg-slate500 text-white',
+        isSunday && 'text-warn500',
+      )}
+    >
+      <span className="text-14M">{dateText}</span>
+    </div>
+  );
+};
+
+type Props = {
+  todos: TodoType[];
+  selectedDate: Date;
+  onDateChange: (date: Date) => void;
+  calendarRef: React.RefObject<FullCalendar>;
+  onDropTodo: (date: string, todoId: number) => void;
+};
+
+export default function CalendarBody({
+  todos,
+  selectedDate,
+  onDateChange,
+  calendarRef,
+  onDropTodo,
+}: Props) {
+  /**
+   * 셀에 클래스 부여
+   */
+  const getDayCellClassNames = (info: { date: Date }) => {
+    const isSelectedDate =
+      selectedDate.toDateString() === info.date.toDateString();
+
+    return cn(isSelectedDate && 'selected');
+  };
+
+  /**
+   * 각 날짜 칸을 클릭을 처리하는 핸들러
+   */
+  const handleDateClick = useCallback(
+    (info: { date: Date }) => {
+      onDateChange(new Date(info.date));
+    },
+    [onDateChange],
+  );
+
+  /**
+   * 이벤트를 클릭해도 선택 날짜 변경
+   */
+  const handleEventClick = (info: EventClickArg) => {
+    if (info.event.start) {
+      onDateChange(new Date(info.event.start)); // 선택된 날짜 변경
+    }
+  };
+  /**
+   * 날짜 셀 크기 업데이트
+   */
+  const updateCellSize = () => {
+    const cell = document.querySelector('.fc-daygrid-day');
+    if (cell) {
+      const width = cell.clientWidth;
+      document.querySelectorAll('.fc-daygrid-day').forEach((el) => {
+        const cellElement = el as HTMLElement;
+        if (width < 120) {
+          cellElement.style.height = `${width}px`;
+        } else {
+          cellElement.style.height = '120px';
+        }
+        cellElement.style.minHeight = `${width}px`;
+      });
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', updateCellSize);
+    updateCellSize(); // 초기 설정
+
+    return () => window.removeEventListener('resize', updateCellSize);
+  }, []);
+
+  /**
+   * 사이드 바가 접히거나 펼쳐지면 캘린더 크기 재조정
+   */
+  useEffect(() => {
+    const sidebar = document.querySelector('nav'); // 사이드바 선택
+    if (!sidebar) return undefined;
+
+    const observer = new MutationObserver(() => {
+      setTimeout(() => {
+        window.dispatchEvent(new Event('resize'));
+      }, 200);
+    });
+
+    observer.observe(sidebar, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <FullCalendar
+      ref={calendarRef}
+      plugins={[dayGridPlugin, interactionPlugin, timeGridPlugin]}
+      initialView="dayGridMonth"
+      events={todos.map((event) => ({
+        ...event,
+        id: event.id.toString(),
+        className: event.goal?.color || 'bg-slate950',
+      }))}
+      eventBorderColor="transparent"
+      eventDisplay="block"
+      dateClick={handleDateClick}
+      eventClick={handleEventClick}
+      locale="kr"
+      headerToolbar={false}
+      dayHeaderFormat={{ weekday: 'long' }}
+      height="auto"
+      contentHeight="100%"
+      dayCellContent={(info) => renderDayCellContent(info)}
+      dayCellClassNames={(info) => getDayCellClassNames(info)}
+      dayCellDidMount={updateCellSize}
+      droppable
+      eventReceive={(info) => {
+        const todoId = Number(info.event.id);
+        const date = info.event.startStr;
+
+        onDropTodo(date, todoId);
+        info.event.remove();
+      }}
+    />
+  );
+}

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -6,7 +6,13 @@ import { DayCellContentArg, EventClickArg } from '@fullcalendar/core';
 import '@/styles/calendar.css';
 import { useCallback, useEffect } from 'react';
 import cn from '@/utils/cn';
-import { TodoType } from '@/types/todos';
+import { Todo } from '@/types/todos';
+
+const goalColor: Record<string, string> = {
+  goal01: 'bg-goal01-100 text-goal01',
+  goal02: 'bg-goal02-100 text-goal02',
+  default: 'bg-slate100 text-slate500',
+};
 
 /**
  * 각 날짜 숫자를 커스텀한 UI
@@ -34,7 +40,7 @@ const renderDayCellContent = (info: DayCellContentArg) => {
 };
 
 interface Props {
-  todos: TodoType[];
+  todos: Todo[];
   selectedDate: Date;
   onDateChange: (date: Date) => void;
   calendarRef: React.RefObject<FullCalendar>;
@@ -144,13 +150,11 @@ export default function CalendarBody({
     observer.observe(info.el);
 
     window.addEventListener('resize', updateCellSize);
-  };
 
-  const getColorClasses = (color?: string) => {
-    return cn({
-      'bg-slate100 text-slate500': !color, // 기본 색상
-      [`bg-${color}-100 text-${color}`]: color, // 동적 색상 적용
-    });
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateCellSize);
+    };
   };
 
   /**
@@ -182,7 +186,7 @@ export default function CalendarBody({
       events={todos.map((event) => ({
         ...event,
         id: event.id.toString(),
-        className: getColorClasses(event.goal?.color),
+        className: goalColor[event.goal?.color || 'default'],
       }))}
       eventBorderColor="transparent"
       eventDisplay="block"

--- a/src/components/todoCalendar/CalendarHeader.tsx
+++ b/src/components/todoCalendar/CalendarHeader.tsx
@@ -3,15 +3,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import FullCalendar from '@fullcalendar/react';
 import { useState } from 'react';
 
-type Props = {
+interface Props {
   calendarRef: React.RefObject<FullCalendar>;
   onDateChange: (date: Date) => void;
-};
+}
 
 /**
  * 캘린더 헤더 부분
  * (달력의 연도와 달, 오늘로 이동하는 버튼, 달 이동 버튼)
- * Todo:: Today 버튼 공용 컴포넌트에서 가져오기
  *
  * @param calendarRef 달력
  * @param onDateChange 선택 날짜 변경
@@ -66,9 +65,9 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
         <button
           type="button"
           onClick={handlePrevMonthClick}
-          className="flex h-7 w-7 items-center justify-center"
+          className="flex size-7 items-center justify-center"
         >
-          <FontAwesomeIcon className="h-4 w-4" icon={faAngleLeft} />
+          <FontAwesomeIcon className="size-4" icon={faAngleLeft} />
         </button>
         <span className="inline-block min-w-32 flex-shrink-0 text-center text-20M text-gsBk">
           {viewMonth.toLocaleDateString('ko-KR', {
@@ -79,9 +78,9 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
         <button
           type="button"
           onClick={handleNextMonthClick}
-          className="flex h-7 w-7 items-center justify-center"
+          className="flex size-7 items-center justify-center"
         >
-          <FontAwesomeIcon className="h-4 w-4" icon={faAngleRight} />
+          <FontAwesomeIcon className="size-4" icon={faAngleRight} />
         </button>
       </div>
       <div className="flex w-1/4 justify-end">

--- a/src/components/todoCalendar/CalendarHeader.tsx
+++ b/src/components/todoCalendar/CalendarHeader.tsx
@@ -76,7 +76,7 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
         <Button
           onClick={() => handleTodayClick()}
           variant="outline"
-          className="w-[84px] rounded-3xl py-2"
+          className="w-[84px] rounded-3xl py-2 2xl:rounded-3xl 2xl:py-2"
         >
           오늘
         </Button>

--- a/src/components/todoCalendar/CalendarHeader.tsx
+++ b/src/components/todoCalendar/CalendarHeader.tsx
@@ -1,7 +1,8 @@
 import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import FullCalendar from '@fullcalendar/react';
 import { useState } from 'react';
+import IconButton from '../common/button/IconButton';
+import Button from '../common/button/Button';
 
 interface Props {
   calendarRef: React.RefObject<FullCalendar>;
@@ -62,35 +63,23 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
     <div className="flex w-full items-center justify-between rounded-t-[20px] border border-gs200 bg-gs50 px-6 py-3">
       <div className="w-1/4" />
       <div className="flex flex-1 items-center justify-center gap-3">
-        <button
-          type="button"
-          onClick={handlePrevMonthClick}
-          className="flex size-7 items-center justify-center"
-        >
-          <FontAwesomeIcon className="size-4" icon={faAngleLeft} />
-        </button>
-        <span className="inline-block min-w-32 flex-shrink-0 text-center text-20M text-gsBk">
+        <IconButton icon={faAngleLeft} onClick={handlePrevMonthClick} />
+        <span className="inline-block min-w-32 shrink-0 text-center text-20M text-gsBk">
           {viewMonth.toLocaleDateString('ko-KR', {
             year: 'numeric',
             month: 'long',
           })}
         </span>
-        <button
-          type="button"
-          onClick={handleNextMonthClick}
-          className="flex size-7 items-center justify-center"
-        >
-          <FontAwesomeIcon className="size-4" icon={faAngleRight} />
-        </button>
+        <IconButton icon={faAngleRight} onClick={handleNextMonthClick} />
       </div>
       <div className="flex w-1/4 justify-end">
-        <button
-          type="button"
-          onClick={handleTodayClick}
-          className="w-[84px] rounded-3xl border border-slate500 py-2 text-14M text-slate500"
+        <Button
+          onClick={() => handleTodayClick()}
+          variant="outline"
+          className="w-[84px] rounded-3xl py-2"
         >
           오늘
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/todoCalendar/CalendarHeader.tsx
+++ b/src/components/todoCalendar/CalendarHeader.tsx
@@ -1,3 +1,5 @@
+import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import FullCalendar from '@fullcalendar/react';
 import { useState } from 'react';
 
@@ -9,6 +11,7 @@ type Props = {
 /**
  * 캘린더 헤더 부분
  * (달력의 연도와 달, 오늘로 이동하는 버튼, 달 이동 버튼)
+ * Todo:: Today 버튼 공용 컴포넌트에서 가져오기
  *
  * @param calendarRef 달력
  * @param onDateChange 선택 날짜 변경
@@ -57,26 +60,18 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
   };
 
   return (
-    <div className="mb-4 flex w-full items-center justify-between">
-      <div className="w-1/4">
-        <button
-          type="button"
-          onClick={handleTodayClick}
-          className="rounded-lg bg-gray-200 p-4"
-        >
-          Today
-        </button>
-      </div>
-      <div className="flex w-1/2 flex-grow-0 items-center justify-center">
+    <div className="flex w-full items-center justify-between rounded-t-[20px] border border-gs200 bg-gs50 px-6 py-3">
+      <div className="w-1/4" />
+      <div className="flex flex-1 items-center justify-center gap-3">
         <button
           type="button"
           onClick={handlePrevMonthClick}
-          className="mr-2 rounded-lg bg-gray-200 px-3 py-2 text-sm font-medium hover:bg-gray-300"
+          className="flex h-7 w-7 items-center justify-center"
         >
-          ←
+          <FontAwesomeIcon className="h-4 w-4" icon={faAngleLeft} />
         </button>
-        <span className="inline-block min-w-32 flex-shrink-0 text-center text-lg font-semibold">
-          {viewMonth.toLocaleDateString('en-US', {
+        <span className="inline-block min-w-32 flex-shrink-0 text-center text-20M text-gsBk">
+          {viewMonth.toLocaleDateString('ko-KR', {
             year: 'numeric',
             month: 'long',
           })}
@@ -84,12 +79,20 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
         <button
           type="button"
           onClick={handleNextMonthClick}
-          className="ml-2 rounded-lg bg-gray-200 px-3 py-2 text-sm font-medium hover:bg-gray-300"
+          className="flex h-7 w-7 items-center justify-center"
         >
-          →
+          <FontAwesomeIcon className="h-4 w-4" icon={faAngleRight} />
         </button>
       </div>
-      <div className="w-1/4" />
+      <div className="flex w-1/4 justify-end">
+        <button
+          type="button"
+          onClick={handleTodayClick}
+          className="w-[84px] rounded-3xl border border-slate500 py-2 text-14M text-slate500"
+        >
+          오늘
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/todoCalendar/TodoBasket.tsx
+++ b/src/components/todoCalendar/TodoBasket.tsx
@@ -2,11 +2,11 @@ import { Draggable } from '@fullcalendar/interaction';
 import { useEffect, useRef } from 'react';
 import { Goal } from '@/types/todos';
 
-type Props = {
+interface Props {
   basketList: { id: number; title: string; goal: Goal | null }[];
   onDeleteBasketTodo: (id: number) => void;
   onDeleteAllBasket: () => void;
-};
+}
 
 export default function TodoBasket({
   basketList,

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -1,25 +1,22 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import Calendar from './Calendar';
-import CalendarHeader from './CalendarHeader';
+
 import TodoList from './TodoList';
 import { BasketType, TodoType } from '@/types/todos';
-import Loading from '../common/Loading';
-import TodoBasket from './TodoBasket';
 import TodoModal from './TodoModal';
+
+// import Loading from '../common/Loading';
+// import TodoBasket from './TodoBasket';
 
 const initialTodos = [
   {
     id: 1,
     title: '할일 1',
     date: '2025-02-03',
-    goal: {
-      id: 1,
-      title: '강의 듣기',
-      color: 'bg-red-500',
-    },
+    goal: null,
     done: true,
   },
   {
@@ -29,7 +26,7 @@ const initialTodos = [
     goal: {
       id: 1,
       title: '강의 듣기',
-      color: 'bg-red-500',
+      color: 'goal01',
     },
     done: true,
   },
@@ -40,7 +37,7 @@ const initialTodos = [
     goal: {
       id: 2,
       title: '목표 2',
-      color: 'bg-indigo-500',
+      color: 'goal02',
     },
     done: true,
   },
@@ -51,7 +48,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: true,
   },
@@ -62,7 +59,7 @@ const initialTodos = [
     goal: {
       id: 4,
       title: '목표 4',
-      color: 'bg-green-500',
+      color: 'goal02',
     },
     done: true,
   },
@@ -73,7 +70,7 @@ const initialTodos = [
     goal: {
       id: 1,
       title: '강의 듣기',
-      color: 'bg-red-500',
+      color: 'goal01',
     },
     done: true,
   },
@@ -85,7 +82,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -96,7 +93,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -107,7 +104,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -118,7 +115,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -129,7 +126,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -140,7 +137,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -151,7 +148,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -162,7 +159,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -173,7 +170,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -184,7 +181,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -195,7 +192,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -206,7 +203,7 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
     },
     done: false,
   },
@@ -217,7 +214,40 @@ const initialTodos = [
     goal: {
       id: 3,
       title: '목표 3',
-      color: 'bg-yellow-500',
+      color: 'goal02',
+    },
+    done: false,
+  },
+  {
+    id: 20,
+    title: '할일이 여러개면 어쩌구 저쩌구',
+    date: '2025-02-03',
+    goal: {
+      id: 3,
+      title: '목표 3',
+      color: 'goal02',
+    },
+    done: false,
+  },
+  {
+    id: 21,
+    title: '할일이 여러개면 어쩌구 저쩌구',
+    date: '2025-02-03',
+    goal: {
+      id: 3,
+      title: '목표 3',
+      color: 'goal02',
+    },
+    done: false,
+  },
+  {
+    id: 22,
+    title: '할일이 여러개면 어쩌구 저쩌구',
+    date: '2025-02-03',
+    goal: {
+      id: 3,
+      title: '목표 3',
+      color: 'goal02',
     },
     done: false,
   },
@@ -245,7 +275,7 @@ const initialBasketList = [
     goal: {
       id: 1,
       title: '강의 듣기',
-      color: 'bg-red-500',
+      color: 'goal01',
     },
   },
 ];
@@ -254,9 +284,9 @@ export default function TodoCalendar() {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [todos, setTodos] = useState<TodoType[]>(initialTodos);
   const [basketList, setBasketList] = useState<BasketType[]>(initialBasketList);
-  const [isCalendarReady, setIsCalendarReady] = useState<boolean>(false);
-  const [calendarHeight, setCalendarHeight] = useState<number>(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  // const [isCalendarReady, setIsCalendarReady] = useState<boolean>(false);
+  // const [calendarHeight, setCalendarHeight] = useState<number>(0);
   const calendarRef = useRef<FullCalendar>(null);
 
   const handleOpenModal = () => setIsModalOpen(true);
@@ -265,16 +295,17 @@ export default function TodoCalendar() {
   /**
    * 캘린더 높이 가져와서 TodoList에 적용
    */
-  const updateCalendarHeight = () => {
-    if (calendarRef.current) {
-      const calendarApi = calendarRef.current.getApi();
-      const calendarEl = (calendarApi as unknown as { el: HTMLElement })?.el;
-      if (calendarEl) {
-        setCalendarHeight(calendarEl.clientHeight);
-        setIsCalendarReady(true);
-      }
-    }
-  };
+  // const updateCalendarHeight = () => {
+  //   if (calendarRef.current) {
+  //     const calendarApi = calendarRef.current.getApi();
+  //     const calendarEl = (calendarApi as unknown as { el: HTMLElement })?.el;
+  //     console.log(calendarEl);
+  //     if (calendarEl) {
+  //       setCalendarHeight(calendarEl.clientHeight);
+  //       setIsCalendarReady(true);
+  //     }
+  //   }
+  // };
 
   /**
    * 할 일의 체크박스 상태 변경
@@ -298,16 +329,16 @@ export default function TodoCalendar() {
    * 장바구니에서 할 일 삭제
    * @param id 삭제할 할 일의 id
    */
-  const handleDeleteBasketTodo = (id: number) => {
-    setBasketList((prev) => prev.filter((todo) => todo.id !== id));
-  };
+  // const handleDeleteBasketTodo = (id: number) => {
+  //   setBasketList((prev) => prev.filter((todo) => todo.id !== id));
+  // };
 
   /**
    * 모든 장바구니 삭제
    */
-  const handleDeleteAllBasket = () => {
-    setBasketList([]);
-  };
+  // const handleDeleteAllBasket = () => {
+  //   setBasketList([]);
+  // };
 
   /**
    * 드랍 시 todo에 추가 & 장바구니에서 제거
@@ -328,69 +359,72 @@ export default function TodoCalendar() {
     setBasketList((prev) => prev.filter((todo) => todo.id !== todoId));
   };
 
-  useEffect(() => {
-    if (calendarRef.current) {
-      const calendarApi = calendarRef.current.getApi();
-      const calendarEl = (calendarApi as unknown as { el: HTMLElement })?.el;
+  // useEffect(() => {
+  //   if (calendarRef.current) {
+  //     const calendarApi = calendarRef.current.getApi();
+  //     const calendarEl = (calendarApi as unknown as { el: HTMLElement })?.el;
 
-      if (calendarEl) {
-        updateCalendarHeight();
-        const observer = new MutationObserver(() => {
-          updateCalendarHeight();
-        });
+  //     if (calendarEl) {
+  //       updateCalendarHeight();
+  //       const observer = new MutationObserver(() => {
+  //         updateCalendarHeight();
+  //       });
 
-        observer.observe(calendarEl, {
-          attributes: true,
-          childList: true,
-          subtree: true,
-        });
-        return () => observer.disconnect();
-      }
-    }
+  //       observer.observe(calendarEl, {
+  //         attributes: true,
+  //         childList: true,
+  //         subtree: true,
+  //       });
+  //       return () => observer.disconnect();
+  //     }
+  //   }
 
-    return undefined;
-  }, []);
+  //   return undefined;
+  // }, []);
 
   return (
-    <div className="flex flex-col items-center p-4">
-      {isCalendarReady && (
-        <CalendarHeader
-          calendarRef={calendarRef}
-          onDateChange={setSelectedDate}
+    <div className="flex flex-col p-[20px] md:flex-row xl:p-[50px] 2xl:p-[80px]">
+      <Calendar
+        todos={todos}
+        selectedDate={selectedDate}
+        onDateChange={setSelectedDate}
+        onDropTodo={handleDropTodo}
+        calendarRef={calendarRef}
+      />
+      {/* <div
+        className="flex h-full w-full flex-grow flex-col justify-between border border-l-0 border-calBorder bg-white p-4 transition-all duration-200 ease-in-out md:w-[30%]"
+        style={{ height: calendarHeight }}
+      > */}
+      <div className="lg:maw-w-[120px] 2xl:max-w-[350px]">
+        <TodoList
+          selectedDate={selectedDate}
+          onToggleTodo={handleToggleTodo}
+          todos={todos.filter(
+            (todo) =>
+              new Date(todo.date).toDateString() ===
+              selectedDate.toDateString(),
+          )}
+          onDeleteTodo={handleDeleteTodo}
+          onOpenModal={handleOpenModal}
         />
-      )}
-      <div className="flex h-full w-full flex-col items-center md:flex-row">
-        <div className="h-full w-full flex-grow transition-all duration-300 ease-in-out md:w-[70%]">
-          <Calendar
-            todos={todos}
-            selectedDate={selectedDate}
-            onDateChange={setSelectedDate}
-            calendarRef={calendarRef}
-            onDropTodo={handleDropTodo}
-          />
-        </div>
-        {isCalendarReady ? (
-          <div
-            className="flex h-full w-full flex-grow flex-col justify-between border border-l-0 border-calBorder bg-white p-4 transition-all duration-200 ease-in-out md:w-[30%]"
-            style={{ height: calendarHeight }}
-          >
-            <TodoList
-              selectedDate={selectedDate}
-              onToggleTodo={handleToggleTodo}
-              todos={todos.filter(
-                (todo) =>
-                  new Date(todo.date).toDateString() ===
-                  selectedDate.toDateString(),
-              )}
-              onDeleteTodo={handleDeleteTodo}
-              onOpenModal={handleOpenModal}
-            />
-          </div>
-        ) : (
-          <Loading />
-        )}
       </div>
-      {isCalendarReady && (
+      {/* </div> */}
+      {/* <div className="h-full w-full flex-grow transition-all duration-300 ease-in-out md:w-[70%]">
+          <Calendar
+          todos={todos}
+          selectedDate={selectedDate}
+          onDateChange={setSelectedDate}
+          calendarRef={calendarRef}
+          onDropTodo={handleDropTodo}
+          />
+          </div> */}
+      {/* {isCalendarReady ? ( */}
+      {/* ) : (
+          <Loading />
+          )} */}
+      {/* <div className="flex h-full w-full flex-col items-center md:flex-row">
+      </div> */}
+      {/* {isCalendarReady && (
         <TodoBasket
           basketList={basketList}
           onDeleteBasketTodo={handleDeleteBasketTodo}
@@ -398,6 +432,7 @@ export default function TodoCalendar() {
         />
       )}
 
+      )} */}
       {isModalOpen && (
         <TodoModal
           selectedDate={selectedDate}

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -5,7 +5,7 @@ import FullCalendar from '@fullcalendar/react';
 import Calendar from './Calendar';
 
 import TodoList from './TodoList';
-import { BasketType, TodoType } from '@/types/todos';
+import { Basket, Todo } from '@/types/todos';
 import TodoModal from './TodoModal';
 
 // import Loading from '../common/Loading';
@@ -282,8 +282,8 @@ const initialBasketList = [
 
 export default function TodoCalendar() {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
-  const [todos, setTodos] = useState<TodoType[]>(initialTodos);
-  const [basketList, setBasketList] = useState<BasketType[]>(initialBasketList);
+  const [todos, setTodos] = useState<Todo[]>(initialTodos);
+  const [basketList, setBasketList] = useState<Basket[]>(initialBasketList);
   const [isModalOpen, setIsModalOpen] = useState(false);
   // const [isCalendarReady, setIsCalendarReady] = useState<boolean>(false);
   // const [calendarHeight, setCalendarHeight] = useState<number>(0);
@@ -347,7 +347,7 @@ export default function TodoCalendar() {
     const draggedTodo = basketList.find((todo) => todo.id === todoId);
     if (!draggedTodo) return;
 
-    const newTodo: TodoType = {
+    const newTodo: Todo = {
       id: todoId,
       title: draggedTodo.title,
       date,

--- a/src/components/todoCalendar/TodoList.tsx
+++ b/src/components/todoCalendar/TodoList.tsx
@@ -1,13 +1,13 @@
 import { TodoType } from '@/types/todos';
 import TodoListItem from './TodoListItem';
 
-type Props = {
+interface Props {
   selectedDate: Date;
   todos: TodoType[];
   onToggleTodo: (id: number) => void;
   onDeleteTodo: (id: number) => void;
   onOpenModal: () => void;
-};
+}
 
 /**
  * 각 날짜의 할 일 목록을 보여주는 컴포넌트
@@ -25,7 +25,7 @@ export default function TodoList({
   const incompleteTodos = todos.filter((todo) => !todo.done);
   const compoleteTodos = todos.filter((todo) => todo.done);
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full w-full flex-col">
       <h2 className="mb-3 flex justify-between text-lg font-bold">
         {selectedDate.toLocaleDateString('ko-KR', {
           month: 'long',

--- a/src/components/todoCalendar/TodoList.tsx
+++ b/src/components/todoCalendar/TodoList.tsx
@@ -1,9 +1,9 @@
-import { TodoType } from '@/types/todos';
+import { Todo } from '@/types/todos';
 import TodoListItem from './TodoListItem';
 
 interface Props {
   selectedDate: Date;
-  todos: TodoType[];
+  todos: Todo[];
   onToggleTodo: (id: number) => void;
   onDeleteTodo: (id: number) => void;
   onOpenModal: () => void;
@@ -25,7 +25,7 @@ export default function TodoList({
   const incompleteTodos = todos.filter((todo) => !todo.done);
   const compoleteTodos = todos.filter((todo) => todo.done);
   return (
-    <div className="flex h-full w-full flex-col">
+    <div className="flex size-full flex-col">
       <h2 className="mb-3 flex justify-between text-lg font-bold">
         {selectedDate.toLocaleDateString('ko-KR', {
           month: 'long',

--- a/src/components/todoCalendar/TodoListItem.tsx
+++ b/src/components/todoCalendar/TodoListItem.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStickyNote, faEllipsisV } from '@fortawesome/free-solid-svg-icons';
-import { TodoType } from '@/types/todos';
+import { Todo } from '@/types/todos';
 import cn from '@/utils/cn';
 
 type Props = {
-  todoList: TodoType[];
+  todoList: Todo[];
   type: '미완료' | '완료';
   onToggleTodo: (id: number) => void;
   isCompleted: boolean;

--- a/src/presets/colors.ts
+++ b/src/presets/colors.ts
@@ -1,5 +1,6 @@
 const colors = {
   gs00: '#FFFFFF',
+  gs20: '#FCFDFE',
   gs50: '#F8FAFC',
   gs100: '#F1F5F9',
   gs200: '#E2E8F0',

--- a/src/presets/colors.ts
+++ b/src/presets/colors.ts
@@ -17,8 +17,15 @@ const colors = {
   warn50: '#FFF2F2',
   warn500: '#EE1E1E',
 
-  goal01: '#9747FF',
-  goal02: '#F86F65',
+  goal01: {
+    100: '#EFE6FB',
+    DEFAULT: '#9747FF',
+  },
+
+  goal02: {
+    100: '#FFE6E4',
+    DEFAULT: '#F86F65',
+  },
 
   slate50: '#EFF6FF',
   slate100: '#DBEAFE',

--- a/src/presets/fontSize.ts
+++ b/src/presets/fontSize.ts
@@ -16,6 +16,8 @@ const fontSize: {
   '18M': ['1.125rem', { lineHeight: '1.75rem', fontWeight: '500' }],
   '18SB': ['1.125rem', { lineHeight: '1.75rem', fontWeight: '600' }],
 
+  '20M': ['1.25rem', { lineHeight: '1.75rem', fontWeight: '500' }],
+
   '40L': ['2.125rem', { lineHeight: '2rem', fontWeight: '300' }],
   '50L': ['3.125rem', { lineHeight: '1.25rem', fontWeight: '300' }],
 };

--- a/src/presets/fontSize.ts
+++ b/src/presets/fontSize.ts
@@ -3,6 +3,7 @@ const fontSize: {
 } = {
   '12R': ['0.75rem', { lineHeight: '1rem', fontWeight: '400' }],
   '12M': ['0.75rem', { lineHeight: '1rem', fontWeight: '500' }],
+  '12SB': ['0.75rem', { lineHeight: '1rem', fontWeight: '600' }],
 
   '14R': ['0.875rem', { lineHeight: '1.25rem', fontWeight: '400' }],
   '14M': ['0.875rem', { lineHeight: '1.25rem', fontWeight: '500' }],

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -33,6 +33,10 @@
   @apply bg-gs20;
 }
 
+.fc-day-other .fc-event {
+  opacity: 0.5 !important;
+}
+
 .fc-daygrid-day-number {
   padding: 8px !important;
 }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 .fc-day {
-  @apply bg-white;
+  @apply bg-gs00;
 }
 
 /* 이벤트 스타일 */
@@ -13,7 +13,7 @@
 
 /* 오늘 날짜 기본 배경색 제거 */
 .fc-day-today {
-  @apply bg-white !important;
+  @apply bg-gs00 !important;
 }
 
 .fc-event {
@@ -28,6 +28,11 @@
 /* 각 셀의 높이 초기화 */
 .fc-daygrid-day {
   min-height: unset !important;
+  border: 0.5px solid #e2e8f0 !important;
+}
+
+.fc-col-header-cell {
+  @apply border-[0.5px] border-gs200 bg-gs50 py-2 text-14M text-gs500 !important;
 }
 
 .fc-daygrid-day-top > a {
@@ -35,5 +40,14 @@
 }
 
 .fc-daygrid-day-events {
-  line-height: 1.3 !important; /* ✅ 이벤트 간의 간격을 줄임 */
+  line-height: 1.3 !important;
+}
+
+.fc-day-other {
+  @apply bg-gs20;
+}
+
+.fc-daygrid-day.selected {
+  outline: 2px solid #3b82f6 !important;
+  outline-offset: -2px;
 }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -2,32 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
-.fc-day {
-  @apply bg-gs00;
-}
-
-/* 이벤트 스타일 */
-.fc-event {
-  @apply overflow-hidden text-ellipsis whitespace-nowrap; /* 이벤트 내용 숨김 처리 */
-}
-
 /* 오늘 날짜 기본 배경색 제거 */
 .fc-day-today {
   @apply bg-gs00 !important;
 }
 
-.fc-event {
-  font-size: 12px !important;
-}
-
-/* 세 번째 이벤트부터 안보이게 설정 */
-.fc-daygrid-day-events > *:nth-child(n + 3) {
-  display: none !important;
-}
-
-/* 각 셀의 높이 초기화 */
 .fc-daygrid-day {
+  @apply bg-gs00;
+  min-width: 30px;
   min-height: unset !important;
+  max-width: 120px !important;
   border: 0.5px solid #e2e8f0 !important;
 }
 
@@ -37,10 +21,6 @@
 
 .fc-daygrid-day-top > a {
   padding-bottom: 1px !important;
-}
-
-.fc-daygrid-day-events {
-  line-height: 1.3 !important;
 }
 
 .fc-day-other {
@@ -57,4 +37,58 @@
 }
 .fc-daygrid-day-top {
   flex-direction: row !important;
+}
+
+.fc-scrollgrid {
+  max-width: 840px !important;
+  width: 100%;
+}
+
+/* 이벤트 스타일 */
+.fc-event {
+  @apply text-12SB mx-0 overflow-hidden text-ellipsis whitespace-nowrap px-[6px] py-[2px] !important;
+  border-radius: 2px;
+  line-height: 0.75rem;
+}
+
+.fc-daygrid-day-events {
+  padding: 8px 4px;
+  margin-bottom: 0 !important;
+  margin-top: 0.5rem !important;
+}
+
+.fc-event-main {
+  color: unset !important;
+}
+
+/* 기본: 4번째 이벤트부터 숨김 */
+.fc-daygrid-day-events > *:nth-child(n + 4) {
+  display: none !important;
+}
+
+/* 📌 화면 너비가 768px 이하일 때 → 3번째 이벤트부터 숨김 */
+@media (max-width: 1024px) {
+  .fc-daygrid-day-events > *:nth-child(n + 3) {
+    display: none !important;
+  }
+  .fc-daygrid-day-events {
+    margin-top: 0.25rem;
+  }
+  .fc-event {
+    line-height: 12px;
+  }
+}
+
+/* 📌 화면 너비가 480px 이하일 때 → 2번째 이벤트부터 숨김 */
+@media (max-width: 768px) {
+  .fc-daygrid-day-events > *:nth-child(n + 2) {
+    display: none !important;
+  }
+  .fc-event {
+    font-size: 8px;
+  }
+  .fc-daygrid-day-events {
+    margin-top: 0.15rem !important;
+    padding-top: 4px !important;
+  }
 }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -13,6 +13,12 @@
   min-height: unset !important;
   max-width: 120px !important;
   border: 0.5px solid #e2e8f0 !important;
+  position: relative !important;
+}
+
+.fc-daygrid-day.selected {
+  outline: 2px solid #3b82f6 !important;
+  outline-offset: -2px;
 }
 
 .fc-col-header-cell {
@@ -25,11 +31,6 @@
 
 .fc-day-other {
   @apply bg-gs20;
-}
-
-.fc-daygrid-day.selected {
-  outline: 2px solid #3b82f6 !important;
-  outline-offset: -2px;
 }
 
 .fc-daygrid-day-number {
@@ -46,7 +47,7 @@
 
 /* 이벤트 스타일 */
 .fc-event {
-  @apply text-12SB mx-0 overflow-hidden text-ellipsis whitespace-nowrap px-[6px] py-[2px] !important;
+  @apply mx-0 overflow-hidden text-ellipsis whitespace-nowrap px-[6px] py-[2px] text-12SB !important;
   border-radius: 2px;
   line-height: 0.75rem;
 }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -51,3 +51,10 @@
   outline: 2px solid #3b82f6 !important;
   outline-offset: -2px;
 }
+
+.fc-daygrid-day-number {
+  padding: 8px !important;
+}
+.fc-daygrid-day-top {
+  flex-direction: row !important;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,6 +5,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --fc-border-color: transparent !important;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,7 +5,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-  --fc-border-color: transparent !important;
+  --fc-border-color: #e2e8f0;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/types/todos.d.ts
+++ b/src/types/todos.d.ts
@@ -1,10 +1,10 @@
 export interface Goal {
   id: number;
   title: string;
-  color: string;
+  color: string | 'default';
 }
 
-export interface TodoType {
+export interface Todo {
   id: number;
   title: string;
   date: string;
@@ -12,7 +12,7 @@ export interface TodoType {
   done: boolean;
 }
 
-export interface BasketType {
+export interface Basket {
   id: number;
   title: string;
   goal: Goal | null;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,14 +19,6 @@ const config: Config = {
       },
     },
   },
-  safelist: [
-    {
-      pattern: /bg-goal(01|02)-(100|DEFAULT)/,
-    },
-    {
-      pattern: /text-goal(01|02)/,
-    },
-  ],
   plugins: [],
 };
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,14 @@ const config: Config = {
       },
     },
   },
+  safelist: [
+    {
+      pattern: /bg-goal(01|02)-(100|DEFAULT)/,
+    },
+    {
+      pattern: /text-goal(01|02)/,
+    },
+  ],
   plugins: [],
 };
 export default config;


### PR DESCRIPTION
<!-- title: "[CAN-/커밋 컨벤션의 타입] 제목" -->
<!-- 예시 [CAN-123/feat] admin page 추가 / [CAN-123/refactor] 테스트 후 접근성 개선 -->

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`
피그마에 있는 캘린더 디자인 적용

## 작업내용 📝

`해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`
- tailwind를 사용하여 캘린더 내부 스타일링에 접근할 수 없어서 css 파일로 스타일링
- 기존 fullCalendar의 스타일을 덮어쓰려면 important없이 스타일링 불가
- 숨겨진 할 일 개수 표시
- 숨겨진 할 일 개수는 페이지가 작아지면서 캘린더 셀 크기가 작아지면 보여줄 곳이 없어서 숨김처리하였음
- 동적으로 목표 글자색과 배경색을 넣어주기 위해서 tailwind 설정
- 현재 할 일이 있는 날짜 클릭 시 해당 부분이 캘린더 영역을 잡아먹는 이슈는 추후 할 일 목록 디자인 적용 시 해결 예정
- todoCalendar 컴포넌트에서 변경 사항 주석 처리(eslint 에러 해결 위해서 임시로 주석처리하였음)

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<img width="659" alt="image" src="https://github.com/user-attachments/assets/d74b4354-0193-45e9-86d6-6b4d5634bd19" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
  - 모듈식 캘린더 인터페이스 도입으로 헤더와 본문이 분리되어 드래그 앤 드롭 및 반응형 기능 제공
  - 내비게이션 버튼에 아이콘 적용 및 한글 날짜 표기로 사용자 경험 향상
  - 새로운 글꼴 크기 및 세분화된 색상 옵션 추가
  - 새로운 색상 및 글꼴 크기 정의 추가

- **리팩토링**
  - 캘린더와 할 일 목록 구조 단순화 및 일부 기능 정리
  - 타입 정의 변경 및 일관성 있는 인터페이스 이름으로 업데이트

- **스타일 개선**
  - 전반적인 캘린더 스타일 업데이트 및 미디어 쿼리 도입으로 다양한 화면에서 최적의 표시 보장
  - CSS 클래스 추가 및 기존 클래스 수정으로 사용자 인터페이스 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->