### PR TITLE
[CAN-37/style] 할 일 목록 디자인 적용

### DIFF
--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -10,9 +10,9 @@ const ButtonVariants = cva(
     variants: {
       variant: {
         default:
-          '!text-14SB 2xl:!text-16SB bg-slate500 text-gs00 hover:bg-slate800 focus:bg-slate800 active:bg-slate800 disabled:bg-gs200 disabled:text-gs400',
+          'bg-slate500 !text-14SB text-gs00 hover:bg-slate800 focus:bg-slate800 active:bg-slate800 disabled:bg-gs200 disabled:text-gs400 2xl:!text-16SB',
         outline:
-          '!text-14M 2xl:!text-16M border border-slate500 bg-gs00 text-slate500 hover:border-slate800 hover:text-slate800 focus:border-slate800 focus:text-slate800 active:border-slate800 active:text-slate800 disabled:border-gs400 disabled:text-gs400',
+          'border border-slate500 bg-gs00 !text-14M text-slate500 hover:border-slate800 hover:text-slate800 focus:border-slate800 focus:text-slate800 active:border-slate800 active:text-slate800 disabled:border-gs400 disabled:text-gs400 2xl:!text-16M',
       },
       size: {
         default: 'px-2 py-1',

--- a/src/components/common/todo/CheckTodo.tsx
+++ b/src/components/common/todo/CheckTodo.tsx
@@ -10,11 +10,12 @@ import {
 import cn from '@/utils/cn';
 import IconButton from '../button/IconButton';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { Goal } from '@/types/todos';
 
 interface Props {
   id: number;
   title: string;
-  goalTitle?: string;
+  goal: Goal | null;
   done: boolean;
   noteId: number | null;
   onCheck?: () => void;
@@ -24,19 +25,19 @@ interface Props {
 
 /**
  *
- * id: 할 일 id
- * title: 할 일 title
- * goalTitle: 목표 이름, 없을 수 있음
- * done: 할 일 완료 여부
- * noteId: 할 일과 관련된 노트 id, 없을 수 있음
- * onCheck: label,check를 클릭 함수
- * onClickNote: 노트 클릭했을 때 함수, 현재까지는 새 노트, 작성된 노트 구분없이 사용
- * onDelete: ... 클리하고 삭제하기 눌렀을 때 함수
+ * @prop id: 할 일 id
+ * @prop title: 할 일 title
+ * @prop goal: 목표, 없을 수 있음
+ * @prop done: 할 일 완료 여부
+ * @prop noteId: 할 일과 관련된 노트 id, 없을 수 있음
+ * @prop onCheck: label,check를 클릭 함수
+ * @prop onClickNote: 노트 클릭했을 때 함수, 현재까지는 새 노트, 작성된 노트 구분없이 사용
+ * @prop onDelete: ... 클리하고 삭제하기 눌렀을 때 함수
  */
 export default function CheckTodo({
   id,
   title,
-  goalTitle,
+  goal,
   done,
   noteId,
   onCheck,
@@ -59,7 +60,13 @@ export default function CheckTodo({
           if (onCheck) onCheck();
         }}
       >
-        <input id={`${id}`} type="checkbox" checked={done} className="hidden" />
+        <input
+          id={`${id}`}
+          type="checkbox"
+          checked={done}
+          className="hidden"
+          onChange={onCheck}
+        />
         <span
           className={cn(
             'flex size-4 flex-none items-center justify-center rounded-[4px] border border-slate500 bg-gs00 2xl:h-5 2xl:w-5',
@@ -68,14 +75,21 @@ export default function CheckTodo({
         >
           {done && <FontAwesomeIcon className="size-3" icon={faCheck} />}
         </span>
-        <p className="flex w-full flex-col 2xl:gap-1">
-          <span className="verflow-hidden text-ellipsis whitespace-nowrap break-words text-12M text-gs500 2xl:text-14M">
-            {goalTitle}
-          </span>
+        <p className="flex min-w-0 flex-1 flex-col 2xl:gap-1">
+          {goal !== null && !done && (
+            <span
+              className={cn(
+                'overflow-hidden text-ellipsis whitespace-nowrap break-words text-12M text-gs500 2xl:text-14M',
+                goal?.color ? `text-${goal.color}` : 'text-slate500',
+              )}
+            >
+              {goal?.title}
+            </span>
+          )}
           <span
             className={cn(
               done && 'text-gs400 line-through',
-              'w-full flex-1 overflow-hidden text-ellipsis whitespace-nowrap break-words text-14R 2xl:text-16R',
+              'overflow-hidden text-ellipsis whitespace-nowrap break-words text-14R 2xl:text-16R',
             )}
           >
             {title}
@@ -98,7 +112,10 @@ export default function CheckTodo({
           <IconButton
             className="flex-none rounded-2xl bg-gs50 text-gs400 group-hover:bg-gs00 md:hidden md:group-hover:flex"
             icon={faEllipsisVertical}
-            onClick={() => setIsMenuOpen(true)}
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsMenuOpen(true);
+            }}
           />
           {isMenuOpen && (
             <nav

--- a/src/components/todoCalendar/Calendar.tsx
+++ b/src/components/todoCalendar/Calendar.tsx
@@ -7,6 +7,7 @@ import CalendarHeader from './CalendarHeader';
 interface Props {
   todos: Todo[];
   selectedDate: Date;
+  isCalendarLoaded: boolean;
   calendarDivRef: React.RefObject<HTMLDivElement>;
   onDateChange: (date: Date) => void;
   onDropTodo: (date: string, todoId: number) => void;
@@ -24,6 +25,7 @@ interface Props {
 export default function Calendar({
   todos,
   selectedDate,
+  isCalendarLoaded,
   calendarDivRef,
   onDateChange,
   onDropTodo,
@@ -31,7 +33,9 @@ export default function Calendar({
   const calendarRef = useRef<FullCalendar>(null);
   return (
     <div ref={calendarDivRef}>
-      <CalendarHeader calendarRef={calendarRef} onDateChange={onDateChange} />
+      {isCalendarLoaded && (
+        <CalendarHeader calendarRef={calendarRef} onDateChange={onDateChange} />
+      )}
       <CalendarBody
         todos={todos}
         selectedDate={selectedDate}

--- a/src/components/todoCalendar/Calendar.tsx
+++ b/src/components/todoCalendar/Calendar.tsx
@@ -1,4 +1,5 @@
 import FullCalendar from '@fullcalendar/react';
+import { useRef } from 'react';
 import { Todo } from '@/types/todos';
 import CalendarBody from './CalendarBody';
 import CalendarHeader from './CalendarHeader';
@@ -6,7 +7,7 @@ import CalendarHeader from './CalendarHeader';
 interface Props {
   todos: Todo[];
   selectedDate: Date;
-  calendarRef: React.RefObject<FullCalendar>;
+  calendarDivRef: React.RefObject<HTMLDivElement>;
   onDateChange: (date: Date) => void;
   onDropTodo: (date: string, todoId: number) => void;
 }
@@ -16,19 +17,20 @@ interface Props {
  * 캘린더 헤더 + 바디
  * @param todos 할 일 전체
  * @param selectedDate 선택된 날짜
- * @param calendarRef 캘린더의 ref
+ * @param calendarDivRef 전체 캘린더의 ref
  * @param onDateChange 선택 날짜 변경 함수
  * @param onDropTodo 장바구니에서 드래그&드롭 한 요소 드롭 적용 함수
  */
 export default function Calendar({
   todos,
   selectedDate,
-  calendarRef,
+  calendarDivRef,
   onDateChange,
   onDropTodo,
 }: Props) {
+  const calendarRef = useRef<FullCalendar>(null);
   return (
-    <div>
+    <div ref={calendarDivRef}>
       <CalendarHeader calendarRef={calendarRef} onDateChange={onDateChange} />
       <CalendarBody
         todos={todos}

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -95,12 +95,12 @@ export default function CalendarBody({
         const width = cell.clientWidth;
         document.querySelectorAll('.fc-daygrid-day').forEach((el) => {
           const cellElement = el as HTMLElement;
-          if (width < 118) {
+          if (width < 96) {
             cellElement.style.height = `${width}px`;
             cellElement.style.minHeight = `${width}px`;
           } else {
-            cellElement.style.height = '124px';
-            cellElement.style.minHeight = '124px';
+            cellElement.style.height = '100px';
+            cellElement.style.minHeight = '100px';
           }
         });
       }

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -39,6 +39,21 @@ const renderDayCellContent = (info: DayCellContentArg) => {
   );
 };
 
+/**
+ * 요일 헤더 반응형 UI
+ * 768 이하에서는 '요일'표시 제거
+ */
+const dayHeaderContent = (args: { text: string }) => {
+  return (
+    <div>
+      <div>
+        <span className="hidden md:inline">{args.text}</span>
+        <span className="md:hidden">{args.text.slice(0, 1)}</span>
+      </div>
+    </div>
+  );
+};
+
 interface Props {
   todos: Todo[];
   selectedDate: Date;
@@ -86,16 +101,26 @@ export default function CalendarBody({
   /**
    * 날짜 셀 크기 업데이트
    */
-
   const handleDayCellMount = (info: { el: HTMLElement }) => {
     // 반응형에 맞춰 셀 크기 업데이트
     const updateCellSize = () => {
       const cell = document.querySelector('.fc-daygrid-day');
+      const screenWidth = window.innerWidth;
+
       if (cell) {
         const width = cell.clientWidth;
         document.querySelectorAll('.fc-daygrid-day').forEach((el) => {
           const cellElement = el as HTMLElement;
-          if (width < 96) {
+
+          if (screenWidth <= 1470) {
+            if (width < 90) {
+              cellElement.style.height = `${width}px`;
+              cellElement.style.minHeight = `${width}px`;
+            } else {
+              cellElement.style.height = '80px';
+              cellElement.style.minHeight = '80px';
+            }
+          } else if (width < 96) {
             cellElement.style.height = `${width}px`;
             cellElement.style.minHeight = `${width}px`;
           } else {
@@ -194,7 +219,9 @@ export default function CalendarBody({
       eventClick={handleEventClick}
       locale="kr"
       headerToolbar={false}
+      dayHeaderContent={dayHeaderContent}
       dayHeaderFormat={{ weekday: 'long' }}
+      dayHeaderClassNames="border-[0.5px] border-gs200 bg-gs50 !py-2 text-12M text-gs500 xl:text-14M"
       height="auto"
       contentHeight="100%"
       dayCellContent={(info) => renderDayCellContent(info)}

--- a/src/components/todoCalendar/CalendarHeader.tsx
+++ b/src/components/todoCalendar/CalendarHeader.tsx
@@ -60,15 +60,15 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
   };
 
   return (
-    <div className="flex w-full items-center justify-between rounded-t-[20px] border border-gs200 bg-gs50 px-6 py-3">
+    <div className="flex w-full items-center justify-between rounded-t-[20px] border border-gs200 bg-gs50 p-3 xl:px-6">
       <div className="w-1/4" />
       <div className="flex flex-1 items-center justify-center gap-3">
         <IconButton icon={faAngleLeft} onClick={handlePrevMonthClick} />
-        <span className="inline-block min-w-32 shrink-0 text-center text-20M text-gsBk">
-          {viewMonth.toLocaleDateString('ko-KR', {
-            year: 'numeric',
-            month: 'long',
-          })}
+        <span className="inline-block shrink-0 text-center text-20M text-gsBk">
+          <span className="hidden sm:inline">
+            {viewMonth.toLocaleDateString('ko-KR', { year: 'numeric' })}{' '}
+          </span>
+          {viewMonth.toLocaleDateString('ko-KR', { month: 'long' })}
         </span>
         <IconButton icon={faAngleRight} onClick={handleNextMonthClick} />
       </div>
@@ -76,7 +76,7 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
         <Button
           onClick={() => handleTodayClick()}
           variant="outline"
-          className="w-[84px] rounded-3xl py-2 2xl:rounded-3xl 2xl:py-2"
+          className="rounded-3xl px-4 py-1 xl:w-[84px] 2xl:rounded-3xl 2xl:py-2"
         >
           오늘
         </Button>

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -372,7 +372,7 @@ export default function TodoCalendar() {
 
   return (
     <div className="flex flex-col gap-3 p-[20px] md:flex-row xl:p-[40px] 2xl:px-20 2xl:pt-[60px]">
-      <div className="max-w-[600px] flex-1 xl:max-w-[840px]">
+      <div className="max-w-[560px] flex-1 2xl:max-w-[840px]">
         <Calendar
           todos={todos}
           selectedDate={selectedDate}
@@ -385,7 +385,7 @@ export default function TodoCalendar() {
       </div>
       {isCalendarLoaded && (
         <div
-          className="size-full md:w-[300px] xl:w-[350px]"
+          className="size-full md:w-[280px] xl:w-[350px]"
           style={{ height: calendarHeight }}
         >
           <TodoList

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -6,6 +6,7 @@ import Calendar from './Calendar';
 import TodoList from './TodoList';
 import { Basket, Todo } from '@/types/todos';
 import TodoModal from './TodoModal';
+import Loading from '../common/Loading';
 
 // import Loading from '../common/Loading';
 // import TodoBasket from './TodoBasket';
@@ -285,6 +286,7 @@ export default function TodoCalendar() {
   const [basketList, setBasketList] = useState<Basket[]>(initialBasketList);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [calendarHeight, setCalendarHeight] = useState<number>(0);
+  const [isCalendarLoaded, setIsCalendarLoaded] = useState(false);
   const calendarRef = useRef<HTMLDivElement>(null);
 
   const handleOpenModal = () => setIsModalOpen(true);
@@ -355,6 +357,7 @@ export default function TodoCalendar() {
     if (calendarRef.current) {
       const observer = new MutationObserver(() => {
         updateCalendarHeight();
+        setIsCalendarLoaded(true);
       });
       observer.observe(calendarRef.current, {
         attributes: true,
@@ -368,7 +371,7 @@ export default function TodoCalendar() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-3 p-[20px] md:flex-row xl:p-[50px] 2xl:p-[80px]">
+    <div className="flex flex-col gap-3 p-[20px] md:flex-row xl:p-[40px] 2xl:px-20 2xl:pt-[60px]">
       <div className="max-w-[600px] flex-1 xl:max-w-[840px]">
         <Calendar
           todos={todos}
@@ -376,40 +379,28 @@ export default function TodoCalendar() {
           onDateChange={setSelectedDate}
           onDropTodo={handleDropTodo}
           calendarDivRef={calendarRef}
+          isCalendarLoaded={isCalendarLoaded}
         />
+        {!isCalendarLoaded && <Loading />}
       </div>
-      <div
-        className="size-full md:w-[300px] xl:w-[350px]"
-        style={{ height: calendarHeight }}
-      >
-        <TodoList
-          selectedDate={selectedDate}
-          onToggleTodo={handleToggleTodo}
-          todos={todos.filter(
-            (todo) =>
-              new Date(todo.date).toDateString() ===
-              selectedDate.toDateString(),
-          )}
-          onDeleteTodo={handleDeleteTodo}
-          onOpenModal={handleOpenModal}
-        />
-      </div>
-      {/* </div> */}
-      {/* <div className="h-full w-full flex-grow transition-all duration-300 ease-in-out md:w-[70%]">
-          <Calendar
-          todos={todos}
-          selectedDate={selectedDate}
-          onDateChange={setSelectedDate}
-          calendarRef={calendarRef}
-          onDropTodo={handleDropTodo}
+      {isCalendarLoaded && (
+        <div
+          className="size-full md:w-[300px] xl:w-[350px]"
+          style={{ height: calendarHeight }}
+        >
+          <TodoList
+            selectedDate={selectedDate}
+            onToggleTodo={handleToggleTodo}
+            todos={todos.filter(
+              (todo) =>
+                new Date(todo.date).toDateString() ===
+                selectedDate.toDateString(),
+            )}
+            onDeleteTodo={handleDeleteTodo}
+            onOpenModal={handleOpenModal}
           />
-          </div> */}
-      {/* {isCalendarReady ? ( */}
-      {/* ) : (
-          <Loading />
-          )} */}
-      {/* <div className="flex h-full w-full flex-col items-center md:flex-row">
-      </div> */}
+        </div>
+      )}
       {/* {isCalendarReady && (
         <TodoBasket
           basketList={basketList}

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
-import FullCalendar from '@fullcalendar/react';
+import React, { useEffect, useRef, useState } from 'react';
 import Calendar from './Calendar';
 
 import TodoList from './TodoList';
@@ -285,9 +284,8 @@ export default function TodoCalendar() {
   const [todos, setTodos] = useState<Todo[]>(initialTodos);
   const [basketList, setBasketList] = useState<Basket[]>(initialBasketList);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  // const [isCalendarReady, setIsCalendarReady] = useState<boolean>(false);
-  // const [calendarHeight, setCalendarHeight] = useState<number>(0);
-  const calendarRef = useRef<FullCalendar>(null);
+  const [calendarHeight, setCalendarHeight] = useState<number>(0);
+  const calendarRef = useRef<HTMLDivElement>(null);
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
@@ -295,17 +293,11 @@ export default function TodoCalendar() {
   /**
    * 캘린더 높이 가져와서 TodoList에 적용
    */
-  // const updateCalendarHeight = () => {
-  //   if (calendarRef.current) {
-  //     const calendarApi = calendarRef.current.getApi();
-  //     const calendarEl = (calendarApi as unknown as { el: HTMLElement })?.el;
-  //     console.log(calendarEl);
-  //     if (calendarEl) {
-  //       setCalendarHeight(calendarEl.clientHeight);
-  //       setIsCalendarReady(true);
-  //     }
-  //   }
-  // };
+  const updateCalendarHeight = () => {
+    if (calendarRef.current) {
+      setCalendarHeight(calendarRef.current.clientHeight);
+    }
+  };
 
   /**
    * 할 일의 체크박스 상태 변경
@@ -359,43 +351,37 @@ export default function TodoCalendar() {
     setBasketList((prev) => prev.filter((todo) => todo.id !== todoId));
   };
 
-  // useEffect(() => {
-  //   if (calendarRef.current) {
-  //     const calendarApi = calendarRef.current.getApi();
-  //     const calendarEl = (calendarApi as unknown as { el: HTMLElement })?.el;
+  useEffect(() => {
+    if (calendarRef.current) {
+      const observer = new MutationObserver(() => {
+        updateCalendarHeight();
+      });
+      observer.observe(calendarRef.current, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+      return () => observer.disconnect();
+    }
 
-  //     if (calendarEl) {
-  //       updateCalendarHeight();
-  //       const observer = new MutationObserver(() => {
-  //         updateCalendarHeight();
-  //       });
-
-  //       observer.observe(calendarEl, {
-  //         attributes: true,
-  //         childList: true,
-  //         subtree: true,
-  //       });
-  //       return () => observer.disconnect();
-  //     }
-  //   }
-
-  //   return undefined;
-  // }, []);
+    return undefined;
+  }, []);
 
   return (
-    <div className="flex flex-col p-[20px] md:flex-row xl:p-[50px] 2xl:p-[80px]">
-      <Calendar
-        todos={todos}
-        selectedDate={selectedDate}
-        onDateChange={setSelectedDate}
-        onDropTodo={handleDropTodo}
-        calendarRef={calendarRef}
-      />
-      {/* <div
-        className="flex h-full w-full flex-grow flex-col justify-between border border-l-0 border-calBorder bg-white p-4 transition-all duration-200 ease-in-out md:w-[30%]"
+    <div className="flex flex-col gap-3 p-[20px] md:flex-row xl:p-[50px] 2xl:p-[80px]">
+      <div className="max-w-[600px] flex-1 xl:max-w-[840px]">
+        <Calendar
+          todos={todos}
+          selectedDate={selectedDate}
+          onDateChange={setSelectedDate}
+          onDropTodo={handleDropTodo}
+          calendarDivRef={calendarRef}
+        />
+      </div>
+      <div
+        className="size-full md:w-[300px] xl:w-[350px]"
         style={{ height: calendarHeight }}
-      > */}
-      <div className="lg:maw-w-[120px] 2xl:max-w-[350px]">
+      >
         <TodoList
           selectedDate={selectedDate}
           onToggleTodo={handleToggleTodo}

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -371,8 +371,8 @@ export default function TodoCalendar() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-3 p-[20px] md:flex-row xl:p-[40px] 2xl:px-20 2xl:pt-[60px]">
-      <div className="max-w-[560px] flex-1 2xl:max-w-[840px]">
+    <div className="flex flex-col justify-center gap-4 md:flex-row">
+      <div className="flex-1">
         <Calendar
           todos={todos}
           selectedDate={selectedDate}

--- a/src/components/todoCalendar/TodoList.tsx
+++ b/src/components/todoCalendar/TodoList.tsx
@@ -1,5 +1,11 @@
+import { faAngleUp, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useState } from 'react';
 import { Todo } from '@/types/todos';
 import TodoListItem from './TodoListItem';
+import Button from '../common/button/Button';
+import Icon from '../common/icon/Icon';
+import cn from '@/utils/cn';
 
 interface Props {
   selectedDate: Date;
@@ -22,39 +28,79 @@ export default function TodoList({
   onDeleteTodo,
   onOpenModal,
 }: Props) {
+  const [isCompletedOpen, setIsCompletedOpen] = useState(true);
+
   const incompleteTodos = todos.filter((todo) => !todo.done);
   const compoleteTodos = todos.filter((todo) => todo.done);
+
   return (
-    <div className="flex size-full flex-col">
-      <h2 className="mb-3 flex justify-between text-lg font-bold">
-        {selectedDate.toLocaleDateString('ko-KR', {
-          month: 'long',
-          day: 'numeric',
-        })}
-      </h2>
-      <div className="mb-4 flex flex-1 flex-col gap-4 overflow-y-auto">
-        <TodoListItem
-          todoList={incompleteTodos}
-          type="미완료"
-          onToggleTodo={onToggleTodo}
-          isCompleted={false}
-          onDeleteTodo={onDeleteTodo}
-        />
-        <TodoListItem
-          todoList={compoleteTodos}
-          type="완료"
-          onToggleTodo={onToggleTodo}
-          isCompleted
-          onDeleteTodo={onDeleteTodo}
-        />
+    <div className="flex size-full flex-col rounded-[20px] border-2 border-gs200 bg-gs00">
+      {/* header */}
+      <div className="flex items-center justify-between border-b-2 border-gs200 p-4">
+        <h2 className="text-18SB text-gsBk">할일</h2>
+        <p className="text-14M text-gs500">
+          {`${selectedDate.getFullYear()}년 ${String(selectedDate.getMonth() + 1).padStart(2, '0')}월 ${String(selectedDate.getDate()).padStart(2, '0')}일`}
+        </p>
       </div>
-      <button
-        type="button"
-        onClick={() => onOpenModal()}
-        className="w-full rounded-lg border border-gray-300 p-3 text-sm font-medium text-gray-600 hover:bg-gray-100"
-      >
-        새 할일 생성
-      </button>
+      {/* 할 일 목록 */}
+      <div className="flex flex-1 flex-col gap-8 overflow-hidden p-4">
+        {/* 미완료 */}
+        <div
+          className={cn(
+            'flex min-h-0 flex-1 flex-col transition-all duration-500 ease-in-out',
+            isCompletedOpen ? 'max-h-[50%]' : 'max-h-[85%]',
+          )}
+        >
+          <h3 className="mb-2 text-14M text-gs500">
+            미완료({incompleteTodos.length})
+          </h3>
+          <div className="h-full overflow-y-auto">
+            <TodoListItem
+              todoList={incompleteTodos}
+              onToggleTodo={onToggleTodo}
+              onDeleteTodo={onDeleteTodo}
+            />
+          </div>
+        </div>
+
+        {/* 완료 */}
+        <div
+          className={cn(
+            'flex flex-col overflow-hidden transition-all duration-500 ease-in-out',
+            isCompletedOpen ? 'h-[40%]' : 'h-5',
+          )}
+        >
+          <div className="flex justify-between">
+            <h3 className="mb-2 text-14M text-gs500">
+              완료 ({compoleteTodos.length})
+            </h3>
+            <button
+              type="button"
+              className={cn('size-5 transition-transform duration-300', {
+                'rotate-0': !isCompletedOpen,
+                'rotate-180': isCompletedOpen,
+              })}
+              onClick={() => setIsCompletedOpen((prev) => !prev)}
+            >
+              <FontAwesomeIcon icon={faAngleUp} className="size-3" />
+            </button>
+          </div>
+          {isCompletedOpen && (
+            <div className="h-full overflow-y-auto">
+              <TodoListItem
+                todoList={compoleteTodos}
+                onToggleTodo={onToggleTodo}
+                onDeleteTodo={onDeleteTodo}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="px-4 py-5">
+        <Button variant="outline" size="full" onClick={() => onOpenModal()}>
+          <Icon icon={faPlus} />새 할일 생성
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/todoCalendar/TodoList.tsx
+++ b/src/components/todoCalendar/TodoList.tsx
@@ -31,7 +31,7 @@ export default function TodoList({
   const [isCompletedOpen, setIsCompletedOpen] = useState(true);
 
   const incompleteTodos = todos.filter((todo) => !todo.done);
-  const compoleteTodos = todos.filter((todo) => todo.done);
+  const completeTodos = todos.filter((todo) => todo.done);
 
   return (
     <div className="flex size-full flex-col rounded-[20px] border-2 border-gs200 bg-gs00">
@@ -55,11 +55,17 @@ export default function TodoList({
             미완료({incompleteTodos.length})
           </h3>
           <div className="h-full overflow-y-auto">
-            <TodoListItem
-              todoList={incompleteTodos}
-              onToggleTodo={onToggleTodo}
-              onDeleteTodo={onDeleteTodo}
-            />
+            {incompleteTodos.length > 0 ? (
+              <TodoListItem
+                todoList={incompleteTodos}
+                onToggleTodo={onToggleTodo}
+                onDeleteTodo={onDeleteTodo}
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center text-center text-14M text-gs500">
+                등록된 할 일이 없습니다.
+              </div>
+            )}
           </div>
         </div>
 
@@ -72,7 +78,7 @@ export default function TodoList({
         >
           <div className="flex justify-between">
             <h3 className="mb-2 text-14M text-gs500">
-              완료 ({compoleteTodos.length})
+              완료 ({completeTodos.length})
             </h3>
             <button
               type="button"
@@ -87,11 +93,17 @@ export default function TodoList({
           </div>
           {isCompletedOpen && (
             <div className="h-full overflow-y-auto">
-              <TodoListItem
-                todoList={compoleteTodos}
-                onToggleTodo={onToggleTodo}
-                onDeleteTodo={onDeleteTodo}
-              />
+              {completeTodos.length > 0 ? (
+                <TodoListItem
+                  todoList={completeTodos}
+                  onToggleTodo={onToggleTodo}
+                  onDeleteTodo={onDeleteTodo}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-center text-14M text-gs500">
+                  완료된 할 일이 없습니다.
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/components/todoCalendar/TodoListItem.tsx
+++ b/src/components/todoCalendar/TodoListItem.tsx
@@ -1,131 +1,39 @@
-import { useEffect, useState } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faStickyNote, faEllipsisV } from '@fortawesome/free-solid-svg-icons';
 import { Todo } from '@/types/todos';
-import cn from '@/utils/cn';
+import CheckTodo from '../common/todo/CheckTodo';
 
-type Props = {
+interface Props {
   todoList: Todo[];
-  type: '미완료' | '완료';
   onToggleTodo: (id: number) => void;
-  isCompleted: boolean;
   onDeleteTodo: (id: number) => void;
-};
+}
 
 /**
  * 할 일에 대한 컴포넌트
  * @param todoList 할 일 리스트
- * @param type 완료/미완료
  * @param onToggleTodo 할 일 완료 여부 핸들링
  * @param isCompleted 완료 여부
 
  */
 export default function TodoListItem({
   todoList,
-  type,
   onToggleTodo,
-  isCompleted = false,
   onDeleteTodo,
 }: Props) {
-  const [menuOpen, setMenuOpen] = useState<number | null>(null);
-
-  /**
-   * 메뉴 클릭 핸들러
-   * @param id 클릭한 할 일의 id
-   */
-  const handelToggleMenu = (id: number) => {
-    setMenuOpen((prev) => (prev === id ? null : id));
-  };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuOpen !== null) {
-        const dropdown = document.getElementById(`menu-${menuOpen}`);
-        if (dropdown && !dropdown.contains(event.target as Node)) {
-          setMenuOpen(null);
-        }
-      }
-    };
-
-    if (menuOpen !== null) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [menuOpen]);
-
   return (
-    <div>
-      <h3 className="text-md mb-2 font-semibold text-gray-600">
-        {type} ({todoList.length})
-      </h3>
-      <ul className="space-y-3">
-        {todoList.map((todo) => (
-          <li
-            key={todo.id}
-            className="flex items-center space-x-3 border-b border-gray-200 pb-3 pr-2 last:border-0"
-          >
-            <input
-              type="checkbox"
-              checked={todo.done}
-              onChange={() => onToggleTodo(todo.id)}
-            />
-            <div
-              onClick={() => onToggleTodo(todo.id)}
-              className="grow cursor-pointer overflow-hidden"
-            >
-              {todo.goal && (
-                <p className="truncate text-sm text-gray-400">
-                  {todo.goal.title}
-                </p>
-              )}
-              <p
-                className={cn(
-                  'truncate',
-                  isCompleted && 'text-gray-400 line-through',
-                )}
-              >
-                {todo.title}
-              </p>
-            </div>
-            <div className="flex items-center space-x-4">
-              <button type="button" className="text-gray-500">
-                <FontAwesomeIcon icon={faStickyNote} />
-              </button>
-              <div className="relative">
-                <button
-                  type="button"
-                  className="text-gray-500"
-                  onClick={() => handelToggleMenu(todo.id)}
-                >
-                  <FontAwesomeIcon icon={faEllipsisV} />
-                </button>
-                {menuOpen === todo.id && (
-                  <div
-                    className="absolute right-0 top-8 z-10 w-24 rounded-lg bg-white shadow-md"
-                    id={`menu-${todo.id}`}
-                  >
-                    <button
-                      type="button"
-                      className="w-full px-3 py-2 text-sm hover:bg-gray-100"
-                    >
-                      수정하기
-                    </button>
-                    <button
-                      type="button"
-                      className="w-full px-3 py-2 text-sm hover:bg-gray-100"
-                      onClick={() => onDeleteTodo(todo.id)}
-                    >
-                      삭제하기
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <ul>
+      {todoList.map((todo) => (
+        <li key={todo.id} className="last:border-0">
+          <CheckTodo
+            id={todo.id}
+            title={todo.title}
+            goal={todo.goal}
+            done={todo.done}
+            noteId={null}
+            onCheck={() => onToggleTodo(todo.id)}
+            onDelete={() => onDeleteTodo(todo.id)}
+          />
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -51,7 +51,7 @@
 
 /* 이벤트 스타일 */
 .fc-event {
-  @apply text-12SB mx-0 overflow-hidden text-ellipsis whitespace-nowrap px-[6px] py-[2px] !important;
+  @apply mx-0 overflow-hidden text-ellipsis whitespace-nowrap px-[6px] py-[2px] text-12SB !important;
   border-radius: 2px;
   line-height: 0.75rem;
 }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -37,6 +37,10 @@
   opacity: 0.5 !important;
 }
 
+.fc-day-other.fc-day-today {
+  @apply bg-gs20 !important;
+}
+
 .fc-daygrid-day-number {
   padding: 8px !important;
 }
@@ -67,13 +71,12 @@
 }
 
 /* 기본: 4번째 이벤트부터 숨김 */
-.fc-daygrid-day-events > *:nth-child(n + 4) {
+.fc-daygrid-day-events > *:nth-child(n + 3) {
   display: none !important;
 }
 
-/* 📌 화면 너비가 1440px 이하일 때 → 3번째 이벤트부터 숨김 */
 @media (max-width: 1440px) {
-  .fc-daygrid-day-events > *:nth-child(n + 3) {
+  .fc-daygrid-day-events > *:nth-child(n + 2) {
     display: none !important;
   }
   .fc-daygrid-day-events {
@@ -84,8 +87,7 @@
   }
 }
 
-/* 📌 화면 너비가 1024px 이하일 때 → 2번째 이벤트부터 숨김 */
-@media (max-width: 1024px) {
+/* @media (max-width: 1440px) {
   .fc-daygrid-day-events > *:nth-child(n + 2) {
     display: none !important;
   }
@@ -96,4 +98,4 @@
     margin-top: 0.15rem !important;
     padding-top: 4px !important;
   }
-}
+} */

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -21,10 +21,6 @@
   outline-offset: -2px;
 }
 
-.fc-col-header-cell {
-  @apply border-[0.5px] border-gs200 bg-gs50 py-2 text-14M text-gs500 !important;
-}
-
 .fc-daygrid-day-top > a {
   padding-bottom: 1px !important;
 }
@@ -70,12 +66,12 @@
   color: unset !important;
 }
 
-/* 기본: 4번째 이벤트부터 숨김 */
+/* 기본: 3번째 이벤트부터 숨김 */
 .fc-daygrid-day-events > *:nth-child(n + 3) {
   display: none !important;
 }
 
-@media (max-width: 1440px) {
+@media (max-width: 1470px) {
   .fc-daygrid-day-events > *:nth-child(n + 2) {
     display: none !important;
   }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -51,7 +51,7 @@
 
 /* 이벤트 스타일 */
 .fc-event {
-  @apply mx-0 overflow-hidden text-ellipsis whitespace-nowrap px-[6px] py-[2px] text-12SB !important;
+  @apply text-12SB mx-0 overflow-hidden text-ellipsis whitespace-nowrap px-[6px] py-[2px] !important;
   border-radius: 2px;
   line-height: 0.75rem;
 }
@@ -71,8 +71,8 @@
   display: none !important;
 }
 
-/* 📌 화면 너비가 768px 이하일 때 → 3번째 이벤트부터 숨김 */
-@media (max-width: 1024px) {
+/* 📌 화면 너비가 1440px 이하일 때 → 3번째 이벤트부터 숨김 */
+@media (max-width: 1440px) {
   .fc-daygrid-day-events > *:nth-child(n + 3) {
     display: none !important;
   }
@@ -84,8 +84,8 @@
   }
 }
 
-/* 📌 화면 너비가 480px 이하일 때 → 2번째 이벤트부터 숨김 */
-@media (max-width: 768px) {
+/* 📌 화면 너비가 1024px 이하일 때 → 2번째 이벤트부터 숨김 */
+@media (max-width: 1024px) {
   .fc-daygrid-day-events > *:nth-child(n + 2) {
     display: none !important;
   }


### PR DESCRIPTION
<!-- title: "[CAN-/커밋 컨벤션의 타입] 제목" -->
<!-- 예시 [CAN-123/feat] admin page 추가 / [CAN-123/refactor] 테스트 후 접근성 개선 -->

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

`해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`
- 할 일 목록이 캘린더 전체를 차지해야하기 때문에 ref로 캘린더 높이 가져옴
- 완료된 할 일은 접기 가능 -> height조정으로 애니메이션 추가
- 현재 장바구니 들어갈 자리가 없음
디자인은 캘린더가 5주짜리라서 height가 높게 되어있지만, 달력은 최대 6주까지 가질 수 있기에 height 조정 -> 달력에 나타나는 할 일 개수는 최대 3개에서 2개로 변경하였음

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`

<img width="1915" alt="image" src="https://github.com/user-attachments/assets/8dec0770-a7b2-4b1f-9f94-5a8d82992390" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 버튼 디자인과 캘린더, 일정 목록의 레이아웃 및 여백이 개선되어 보다 깔끔한 인터페이스를 제공합니다.
  
- **New Features**
  - 캘린더에 로딩 상태 표시 기능이 추가되어 로딩 진행 상황을 쉽게 확인할 수 있습니다.
  - 일정 목록이 미완료와 완료 항목으로 구분되어 사용자 경험이 향상되었습니다.
  
- **Refactor**
  - 할 일 항목의 표시 구조가 간소화되어 전반적인 UI 일관성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->