### PR TITLE
[CAN-24/feat] 할 일 생성 API 연동 

### DIFF
--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -25,9 +25,22 @@ export async function POST(req: NextRequest) {
     base: 'BACKEND',
     url: '/todos',
     method: 'POST',
-    body: { todoId: id, goalId, date, done: false, title, createdAt },
+    body: {
+      todoId: id,
+      goalId: goalId ?? null,
+      date,
+      done: false,
+      title,
+      createdAt,
+    },
   });
 
-  const finalData = res2.json();
+  if (!res2.ok) {
+    const message = getErrorMessage(res2.status);
+    return NextResponse.json({ message }, { status: res2.status });
+  }
+
+  const finalData = await res2.json();
+  console.log(finalData);
   return NextResponse.json(finalData, { status: 201 });
 }

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getErrorMessage } from '@/constants/errorMessages';
+import { fetchIntance } from '@/services/fetchInstance';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { title, goalId, date } = body;
+
+  const res1 = await fetchIntance({
+    base: 'CODEIT',
+    method: 'POST',
+    url: '/todos',
+    body: { title, goalId },
+  });
+
+  if (!res1.ok) {
+    const message = getErrorMessage(res1.status);
+    return NextResponse.json({ message }, { status: res1.status });
+  }
+
+  const data = await res1.json();
+  const { id, createdAt } = data;
+
+  const res2 = await fetchIntance({
+    base: 'BACKEND',
+    url: '/todos',
+    method: 'POST',
+    body: { todoId: id, goalId, date, done: false, title, createdAt },
+  });
+
+  const finalData = res2.json();
+  return NextResponse.json(finalData, { status: 201 });
+}

--- a/src/components/common/input/DropDownInput.tsx
+++ b/src/components/common/input/DropDownInput.tsx
@@ -7,14 +7,13 @@ import {
 } from '@headlessui/react';
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Goal } from '@/types/todos';
 import cn from '@/utils/cn';
+import { Goal } from '@/types/goals';
 
 const colorClasses: Record<string, string> = {
   goal01: 'bg-goal01',
   goal02: 'bg-goal02',
-  warn: 'bg-warn500',
-  success: 'bg-success500',
+  default: 'bg-slate500',
 };
 
 // 제네릭 사용하여 컴포넌트를 호출 할 때 타입 전달 받음
@@ -34,7 +33,10 @@ export default function DropDownInput<T extends FieldValues>({
   control,
   disabled = false,
 }: Props<T>) {
-  const extendOptions = [{ id: 0, title: '목표 없음', color: '' }, ...options];
+  const extendOptions = [
+    { goalId: 0, title: '목표 없음', color: '' },
+    ...options,
+  ];
   return (
     <div className="relative w-full">
       {label && (
@@ -49,7 +51,7 @@ export default function DropDownInput<T extends FieldValues>({
           <Listbox
             value={field.value}
             onChange={(selected) =>
-              field.onChange(selected.id === 0 ? null : selected)
+              field.onChange(selected.goalId === 0 ? null : selected)
             }
             disabled={disabled}
           >
@@ -65,12 +67,13 @@ export default function DropDownInput<T extends FieldValues>({
                       'rounded-t-xl border-x-2 border-t-2 border-slate400 bg-gs00 text-gsBk':
                         open,
                     },
-                    { 'text-gsBk': field.value?.id },
+                    { 'text-gsBk': field.value?.goalId },
                   )}
                 >
                   <span className="truncate">
                     {field.value
-                      ? options.find((opt) => opt.id === field.value.id)?.title
+                      ? options.find((opt) => opt.goalId === field.value.goalId)
+                          ?.title
                       : placeholder}
                   </span>
                   <FontAwesomeIcon
@@ -93,7 +96,7 @@ export default function DropDownInput<T extends FieldValues>({
                       <div className="max-h-40 overflow-y-auto">
                         {extendOptions.map((option) => (
                           <ListboxOption
-                            key={option.id}
+                            key={option.goalId}
                             value={option}
                             className={cn(
                               'flex cursor-pointer items-center gap-4 px-4 py-3 text-16R',
@@ -101,7 +104,7 @@ export default function DropDownInput<T extends FieldValues>({
                               'data-[focus]:bg-gs100',
                             )}
                           >
-                            {option.id !== 0 && (
+                            {option.goalId !== 0 && (
                               <span
                                 className={cn(
                                   'h-2 w-2 rounded-full',

--- a/src/components/common/input/DropDownInput.tsx
+++ b/src/components/common/input/DropDownInput.tsx
@@ -24,6 +24,7 @@ type Props<T extends FieldValues> = {
   options: Goal[];
   control: Control<T>;
   disabled?: boolean;
+  isLoading?: boolean;
 };
 export default function DropDownInput<T extends FieldValues>({
   name,
@@ -32,6 +33,7 @@ export default function DropDownInput<T extends FieldValues>({
   options,
   control,
   disabled = false,
+  isLoading = false,
 }: Props<T>) {
   const extendOptions = [
     { goalId: 0, title: '목표 없음', color: '' },
@@ -53,7 +55,7 @@ export default function DropDownInput<T extends FieldValues>({
             onChange={(selected) =>
               field.onChange(selected.goalId === 0 ? null : selected)
             }
-            disabled={disabled}
+            disabled={disabled || isLoading}
           >
             {({ open }) => (
               <div className={cn('relative w-full rounded-xl transition-all')}>
@@ -66,19 +68,24 @@ export default function DropDownInput<T extends FieldValues>({
                         !open,
                       'rounded-t-xl border-x-2 border-t-2 border-slate400 bg-gs00 text-gsBk':
                         open,
+                      'cursor-not-allowed bg-gs200 text-gs400':
+                        disabled || isLoading,
                     },
                     { 'text-gsBk': field.value?.goalId },
                   )}
                 >
                   <span className="truncate">
-                    {field.value
-                      ? options.find((opt) => opt.goalId === field.value.goalId)
-                          ?.title
-                      : placeholder}
+                    {isLoading && '목표를 불러오는 중...'}
+                    {!isLoading &&
+                      field.value &&
+                      options.find((opt) => opt.goalId === field.value.goalId)
+                        ?.title}
+                    {!isLoading && !field.value && placeholder}
                   </span>
+
                   <FontAwesomeIcon
                     icon={faAngleDown}
-                    className={cn('h-4 w-4', { 'rotate-180': open })}
+                    className={cn('size-4', { 'rotate-180': open })}
                   />
                 </ListboxButton>
                 {open && (

--- a/src/components/common/todo/CheckTodo.tsx
+++ b/src/components/common/todo/CheckTodo.tsx
@@ -10,7 +10,7 @@ import {
 import cn from '@/utils/cn';
 import IconButton from '../button/IconButton';
 import { useClickOutside } from '@/hooks/useClickOutside';
-import { Goal } from '@/types/todos';
+import { Goal } from '@/types/goals';
 
 interface Props {
   id: number;

--- a/src/components/todoCalendar/CreateTodo.tsx
+++ b/src/components/todoCalendar/CreateTodo.tsx
@@ -6,19 +6,8 @@ import DropDownInput from '@/components/common/input/DropDownInput';
 import DateInput from '../common/input/DateInput';
 import cn from '@/utils/cn';
 import Button from '../common/button/Button';
-
-const options = [
-  { id: 1, title: '자바스크립트 기초 챕터4 듣기', color: 'goal01' },
-  { id: 2, title: 'React 프로젝트 만들기', color: 'goal02' },
-  { id: 3, title: 'Next.js 학습하기', color: 'goal01' },
-  { id: 4, title: '또 다른 목표', color: 'goal01' },
-  {
-    id: 5,
-    title:
-      '목표가 길어지면 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구',
-    color: 'goal01',
-  },
-];
+import { getErrorMessage } from '@/constants/errorMessages';
+import { useGoals } from '@/hooks/useGoals';
 
 const createTodoSchema = z.object({
   title: z
@@ -44,8 +33,25 @@ export default function CreateTodo({
   onShowConfirmModal,
   savedValues,
 }: Props) {
-  const onSubmit = (formData: TodoFormValues) => {
+  const { data: goalList, isLoading, error } = useGoals();
+
+  // TODO:: tanstack query 도입 후 mutation 사용으로 변경
+  const onSubmit = async (formData: TodoFormValues) => {
     console.log(formData);
+    console.log(formData.date?.toISOString().split('T')[0]);
+    const response = await fetch('/api/todos', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: formData.title,
+        goalId: formData.goal?.goalId,
+        date: formData.date?.toISOString().split('T')[0],
+      }),
+    });
+
+    if (!response.ok) throw new Error(getErrorMessage(response.status));
+    const data = await response.json();
+    console.log('할 일 생성 성공', data);
+
     onCloseModal();
   };
 
@@ -77,13 +83,18 @@ export default function CreateTodo({
             control={control}
             errors={errors}
           />
-          <DropDownInput<TodoFormValues>
-            name="goal"
-            label="목표"
-            placeholder="목표를 선택해주세요"
-            options={options}
-            control={control}
-          />
+          {isLoading && <p>목표를 불러오는 중...</p>}
+          {error && <p className="text-red-500">목표 불러오기 실패</p>}
+          {!isLoading && !error && (
+            <DropDownInput<TodoFormValues>
+              name="goal"
+              label="목표"
+              placeholder="목표를 선택해주세요"
+              options={goalList}
+              control={control}
+            />
+          )}
+
           <DateInput<TodoFormValues>
             name="date"
             label="날짜"

--- a/src/components/todoCalendar/CreateTodo.tsx
+++ b/src/components/todoCalendar/CreateTodo.tsx
@@ -33,12 +33,10 @@ export default function CreateTodo({
   onShowConfirmModal,
   savedValues,
 }: Props) {
-  const { data: goalList, isLoading, error } = useGoals();
+  const { data: goalList, isLoading } = useGoals();
 
   // TODO:: tanstack query 도입 후 mutation 사용으로 변경
   const onSubmit = async (formData: TodoFormValues) => {
-    console.log(formData);
-    console.log(formData.date?.toISOString().split('T')[0]);
     const response = await fetch('/api/todos', {
       method: 'POST',
       body: JSON.stringify({
@@ -49,8 +47,6 @@ export default function CreateTodo({
     });
 
     if (!response.ok) throw new Error(getErrorMessage(response.status));
-    const data = await response.json();
-    console.log('할 일 생성 성공', data);
 
     onCloseModal();
   };
@@ -83,18 +79,14 @@ export default function CreateTodo({
             control={control}
             errors={errors}
           />
-          {isLoading && <p>목표를 불러오는 중...</p>}
-          {error && <p className="text-red-500">목표 불러오기 실패</p>}
-          {!isLoading && !error && (
-            <DropDownInput<TodoFormValues>
-              name="goal"
-              label="목표"
-              placeholder="목표를 선택해주세요"
-              options={goalList}
-              control={control}
-            />
-          )}
-
+          <DropDownInput<TodoFormValues>
+            name="goal"
+            label="목표"
+            placeholder="목표를 선택해주세요"
+            options={goalList}
+            control={control}
+            isLoading={isLoading}
+          />
           <DateInput<TodoFormValues>
             name="date"
             label="날짜"

--- a/src/components/todoCalendar/CreateTodo.tsx
+++ b/src/components/todoCalendar/CreateTodo.tsx
@@ -37,18 +37,21 @@ export default function CreateTodo({
 
   // TODO:: tanstack query 도입 후 mutation 사용으로 변경
   const onSubmit = async (formData: TodoFormValues) => {
-    const response = await fetch('/api/todos', {
-      method: 'POST',
-      body: JSON.stringify({
-        title: formData.title,
-        goalId: formData.goal?.goalId,
-        date: formData.date?.toISOString().split('T')[0],
-      }),
-    });
+    try {
+      const response = await fetch('/api/todos', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: formData.title,
+          goalId: formData.goal?.goalId,
+          date: formData.date?.toISOString().split('T')[0] || null,
+        }),
+      });
 
-    if (!response.ok) throw new Error(getErrorMessage(response.status));
-
-    onCloseModal();
+      if (!response.ok) throw new Error(getErrorMessage(response.status));
+      onCloseModal();
+    } catch (error) {
+      console.log('할 일 생성 중 오류 발생', error);
+    }
   };
 
   const {

--- a/src/components/todoCalendar/TodoBasket.tsx
+++ b/src/components/todoCalendar/TodoBasket.tsx
@@ -1,6 +1,6 @@
 import { Draggable } from '@fullcalendar/interaction';
 import { useEffect, useRef } from 'react';
-import { Goal } from '@/types/todos';
+import { Goal } from '@/types/goals';
 
 interface Props {
   basketList: { id: number; title: string; goal: Goal | null }[];

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -24,9 +24,10 @@ const initialTodos = [
     title: '할일 2',
     date: '2025-02-10',
     goal: {
-      id: 1,
+      goalId: 1,
       title: '강의 듣기',
       color: 'goal01',
+      createdAt: '2025-02-26T02:49:55.691312Z',
     },
     done: true,
   },
@@ -35,9 +36,10 @@ const initialTodos = [
     title: '할일 3',
     date: '2025-02-07',
     goal: {
-      id: 2,
+      goalId: 2,
       title: '목표 2',
       color: 'goal02',
+      createdAt: '2025-02-26T02:49:55.691312Z',
     },
     done: true,
   },
@@ -46,210 +48,12 @@ const initialTodos = [
     title: '할일 4',
     date: '2025-02-20',
     goal: {
-      id: 3,
+      goalId: 3,
       title: '목표 3',
       color: 'goal02',
+      createdAt: '2025-02-26T02:49:55.691312Z',
     },
     done: true,
-  },
-  {
-    id: 5,
-    title: '할일 5',
-    date: '2025-02-17',
-    goal: {
-      id: 4,
-      title: '목표 4',
-      color: 'goal02',
-    },
-    done: true,
-  },
-  {
-    id: 6,
-    title: '할일 6',
-    date: '2025-02-25',
-    goal: {
-      id: 1,
-      title: '강의 듣기',
-      color: 'goal01',
-    },
-    done: true,
-  },
-  {
-    id: 7,
-    title:
-      '할일이 길어지면 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 8,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 9,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 10,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 11,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 12,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 13,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 14,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 15,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 16,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 17,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 18,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 19,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-10',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 20,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-03',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 21,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-03',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
-  },
-  {
-    id: 22,
-    title: '할일이 여러개면 어쩌구 저쩌구',
-    date: '2025-02-03',
-    goal: {
-      id: 3,
-      title: '목표 3',
-      color: 'goal02',
-    },
-    done: false,
   },
 ];
 
@@ -273,9 +77,10 @@ const initialBasketList = [
     id: 116,
     title: '할 일 182',
     goal: {
-      id: 1,
+      goalId: 1,
       title: '강의 듣기',
       color: 'goal01',
+      createdAt: '2025-02-26T02:49:55.691312Z',
     },
   },
 ];
@@ -340,7 +145,6 @@ export default function TodoCalendar() {
   const handleDropTodo = (date: string, todoId: number) => {
     const draggedTodo = basketList.find((todo) => todo.id === todoId);
     if (!draggedTodo) return;
-
     const newTodo: Todo = {
       id: todoId,
       title: draggedTodo.title,
@@ -348,7 +152,6 @@ export default function TodoCalendar() {
       goal: draggedTodo.goal || null,
       done: false,
     };
-
     setTodos((prev) => [...prev, newTodo]);
     setBasketList((prev) => prev.filter((todo) => todo.id !== todoId));
   };

--- a/src/components/todoCalendar/TodoModal.tsx
+++ b/src/components/todoCalendar/TodoModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 import CreateTodo, { TodoFormValues } from './CreateTodo';
 import ConfirmModal from './ConfirmModal';
 
@@ -16,7 +17,7 @@ function TodoModal({ selectedDate, onCloseModal }: Props) {
     setShowConfirmModal(true);
   };
   const handleCloseConfirmModal = () => setShowConfirmModal(false);
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50">
       {!showConfirmModal && (
         <div className="flex w-[520px] flex-col gap-6 rounded-lg bg-gs00 p-6">
@@ -35,7 +36,8 @@ function TodoModal({ selectedDate, onCloseModal }: Props) {
           onConfirm={onCloseModal}
         />
       )}
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/types/todos.d.ts
+++ b/src/types/todos.d.ts
@@ -1,8 +1,4 @@
-export interface Goal {
-  id: number;
-  title: string;
-  color: string | 'default';
-}
+import { Goal } from './goals';
 
 export interface Todo {
   id: number;


### PR DESCRIPTION
<!-- title: "[CAN-/커밋 컨벤션의 타입] 제목" -->
<!-- 예시 [CAN-123/feat] admin page 추가 / [CAN-123/refactor] 테스트 후 접근성 개선 -->

## 작업내용 📝

> 모달 변경
- layout에서 max width 지정하면서 모달창이 차지하는 공간이 사이드바를 제외한 공간으로 변경됨
- 모달창을 body에 직접 추가하여 전체 페이지 너비를 갖도록 변경

> 할 일 생성 시 목표 리스트 조회
- useGoals에서 goal 리스트 가져옴 
- 로딩 상태는 드롭다운 disable 형태를 가지면서 로딩 문구를 띄워주도록 구현
- goal의 type이 확정되면서 해당 type으로 구현 내용 변경 & todo에서 정의했던 goal 삭제

> 할 일 생성 API 연동
- 현재 goal이 있어야 생성 가능 (구현은 없어도 가능하게 되어있습니다)
- 할 일 조회에서 tanstack query 사용하여 구현 예정이라 fetch 부분을 따로 빼지않고 컴포넌트 내에서 구현하였습니다.



## 패키지 설치내용 📦
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 할 일 생성 시 비동기 처리를 통해 서버와 통신하며, 오류 발생 시 안내 메시지를 제공하는 기능을 추가했습니다.
  
- **UI 개선**
  - 목표 선택 입력창에 로딩 상태 표시와 동적 목표 목록 반영 기능이 적용되어 사용자 경험이 향상되었습니다.
  - 할 일 모달 창이 별도 레이어로 오버레이되어 보다 명확하게 표시됩니다.
  
- **데이터 업데이트**
  - 일정 캘린더의 초기 데이터가 정리되고, 목표 항목에 생성 시각 등의 메타데이터가 추가되었습니다.
  - 목표 타입 정의가 통합되어 코드의 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->