### PR TITLE
[CAN-23/feat] 할 일 조회 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@headlessui/react": "^2.2.0",
     "@hookform/resolvers": "^4.0.0",
     "@tanstack/react-query": "^5.66.9",
+    "@tanstack/react-query-devtools": "^5.66.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.66.9
         version: 5.66.9(react@18.3.1)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.66.9
+        version: 5.66.9(@tanstack/react-query@5.66.9(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -448,6 +451,15 @@ packages:
 
   '@tanstack/query-core@5.66.4':
     resolution: {integrity: sha512-skM/gzNX4shPkqmdTCSoHtJAPMTtmIJNS0hE+xwTTUVYwezArCT34NMermABmBVUg5Ls5aiUXEDXfqwR1oVkcA==}
+
+  '@tanstack/query-devtools@5.65.0':
+    resolution: {integrity: sha512-g5y7zc07U9D3esMdqUfTEVu9kMHoIaVBsD0+M3LPdAdD710RpTcLiNvJY1JkYXqkq9+NV+CQoemVNpQPBXVsJg==}
+
+  '@tanstack/react-query-devtools@5.66.9':
+    resolution: {integrity: sha512-70G6AR35he53SYUcUK6EdqNR18zejCv1rM6900gjZP408EAex56YLwVSeijzk9lWeU2J42G9Fjh0i1WngUTsgw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.66.9
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.66.9':
     resolution: {integrity: sha512-NRI02PHJsP5y2gAuWKP+awamTIBFBSKMnO6UVzi03GTclmHHHInH5UzVgzi5tpu4+FmGfsdT7Umqegobtsp23A==}
@@ -2483,6 +2495,14 @@ snapshots:
       tslib: 2.8.1
 
   '@tanstack/query-core@5.66.4': {}
+
+  '@tanstack/query-devtools@5.65.0': {}
+
+  '@tanstack/react-query-devtools@5.66.9(@tanstack/react-query@5.66.9(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.65.0
+      '@tanstack/react-query': 5.66.9(react@18.3.1)
+      react: 18.3.1
 
   '@tanstack/react-query@5.66.9(react@18.3.1)':
     dependencies:

--- a/src/app/api/todos/daily/route.ts
+++ b/src/app/api/todos/daily/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getErrorMessage } from '@/constants/errorMessages';
 import { fetchIntance } from '@/services/fetchInstance';
 
 export async function GET(req: NextRequest) {
@@ -19,17 +18,5 @@ export async function GET(req: NextRequest) {
     url: `/calendar/daily-todos?date=${date}`,
   });
 
-  if (!res.ok) {
-    return NextResponse.json(
-      { message: getErrorMessage(res.status) },
-      { status: res.status },
-    );
-  }
-
-  const data = await res.json();
-
-  if (!Array.isArray(data)) {
-    return NextResponse.json({ message: 'Data is not valid' }, { status: 500 });
-  }
-  return NextResponse.json(data, { status: 200 });
+  return res;
 }

--- a/src/app/api/todos/daily/route.ts
+++ b/src/app/api/todos/daily/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getErrorMessage } from '@/constants/errorMessages';
+import { fetchIntance } from '@/services/fetchInstance';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const date = searchParams.get('date');
+
+  if (!date) {
+    return NextResponse.json(
+      { message: 'year and month and day are required' },
+      { status: 400 },
+    );
+  }
+
+  const res = await fetchIntance({
+    base: 'BACKEND',
+    method: 'GET',
+    url: `/calendar/daily-todos?date=${date}`,
+  });
+
+  if (!res.ok) {
+    return NextResponse.json(
+      { message: getErrorMessage(res.status) },
+      { status: res.status },
+    );
+  }
+
+  const data = await res.json();
+
+  if (!Array.isArray(data)) {
+    return NextResponse.json({ message: 'Data is not valid' }, { status: 500 });
+  }
+  return NextResponse.json(data, { status: 200 });
+}

--- a/src/app/api/todos/monthly/route.ts
+++ b/src/app/api/todos/monthly/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getErrorMessage } from '@/constants/errorMessages';
+import { fetchIntance } from '@/services/fetchInstance';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const year = searchParams.get('year');
+  const month = searchParams.get('month');
+
+  if (!year || !month) {
+    return NextResponse.json(
+      { message: 'year and month are required' },
+      { status: 400 },
+    );
+  }
+  const res = await fetchIntance({
+    base: 'BACKEND',
+    method: 'GET',
+    url: `/calendar/monthly-todos?year=${year}&month=${month}`,
+  });
+
+  if (!res.ok) {
+    return NextResponse.json(
+      { message: getErrorMessage(res.status) },
+      { status: res.status },
+    );
+  }
+  const data = await res.json();
+
+  // data가 잘못 와도 200으로 응답하기 때문에 배열 요소 확인 error 처리
+  if (!Array.isArray(data)) {
+    return NextResponse.json({ message: 'Data is not valid' }, { status: 500 });
+  }
+  return NextResponse.json(data, { status: 200 });
+}

--- a/src/app/api/todos/monthly/route.ts
+++ b/src/app/api/todos/monthly/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getErrorMessage } from '@/constants/errorMessages';
 import { fetchIntance } from '@/services/fetchInstance';
 
 export async function GET(req: NextRequest) {
@@ -18,18 +17,5 @@ export async function GET(req: NextRequest) {
     method: 'GET',
     url: `/calendar/monthly-todos?year=${year}&month=${month}`,
   });
-
-  if (!res.ok) {
-    return NextResponse.json(
-      { message: getErrorMessage(res.status) },
-      { status: res.status },
-    );
-  }
-  const data = await res.json();
-
-  // data가 잘못 와도 200으로 응답하기 때문에 배열 요소 확인 error 처리
-  if (!Array.isArray(data)) {
-    return NextResponse.json({ message: 'Data is not valid' }, { status: 500 });
-  }
-  return NextResponse.json(data, { status: 200 });
+  return res;
 }

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -2,6 +2,38 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getErrorMessage } from '@/constants/errorMessages';
 import { fetchIntance } from '@/services/fetchInstance';
 
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const year = searchParams.get('year');
+  const month = searchParams.get('month');
+
+  if (!year || !month) {
+    return NextResponse.json(
+      { message: 'year and month are required' },
+      { status: 400 },
+    );
+  }
+  const res = await fetchIntance({
+    base: 'BACKEND',
+    method: 'GET',
+    url: `/calendar/monthly-todos?year=${year}&month=${month}`,
+  });
+
+  if (!res.ok) {
+    return NextResponse.json(
+      { message: getErrorMessage(res.status) },
+      { status: res.status },
+    );
+  }
+  const data = await res.json();
+
+  // data가 잘못 와도 200으로 응답하기 때문에 배열 요소 확인 error 처리
+  if (!Array.isArray(data)) {
+    return NextResponse.json({ message: 'Data is not valid' }, { status: 500 });
+  }
+  return NextResponse.json(data, { status: 200 });
+}
+
 export async function POST(req: NextRequest) {
   const body = await req.json();
   const { title, goalId, date } = body;

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -35,12 +35,5 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  if (!res2.ok) {
-    const message = getErrorMessage(res2.status);
-    return NextResponse.json({ message }, { status: res2.status });
-  }
-
-  const finalData = await res2.json();
-  console.log(finalData);
-  return NextResponse.json(finalData, { status: 201 });
+  return res2;
 }

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -2,38 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getErrorMessage } from '@/constants/errorMessages';
 import { fetchIntance } from '@/services/fetchInstance';
 
-export async function GET(req: NextRequest) {
-  const { searchParams } = req.nextUrl;
-  const year = searchParams.get('year');
-  const month = searchParams.get('month');
-
-  if (!year || !month) {
-    return NextResponse.json(
-      { message: 'year and month are required' },
-      { status: 400 },
-    );
-  }
-  const res = await fetchIntance({
-    base: 'BACKEND',
-    method: 'GET',
-    url: `/calendar/monthly-todos?year=${year}&month=${month}`,
-  });
-
-  if (!res.ok) {
-    return NextResponse.json(
-      { message: getErrorMessage(res.status) },
-      { status: res.status },
-    );
-  }
-  const data = await res.json();
-
-  // data가 잘못 와도 200으로 응답하기 때문에 배열 요소 확인 error 처리
-  if (!Array.isArray(data)) {
-    return NextResponse.json({ message: 'Data is not valid' }, { status: 500 });
-  }
-  return NextResponse.json(data, { status: 200 });
-}
-
 export async function POST(req: NextRequest) {
   const body = await req.json();
   const { title, goalId, date } = body;

--- a/src/components/common/ClientProvider.tsx
+++ b/src/components/common/ClientProvider.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactNode, useState } from 'react';
 
 export default function ClientProvider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 }

--- a/src/components/common/todo/CheckTodo.tsx
+++ b/src/components/common/todo/CheckTodo.tsx
@@ -12,6 +12,12 @@ import IconButton from '../button/IconButton';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { Goal } from '@/types/goals';
 
+const goalColor: Record<string, string> = {
+  goal01: 'text-goal01',
+  goal02: 'text-goal02',
+  default: 'text-slate500',
+};
+
 interface Props {
   id: number;
   title: string;
@@ -81,7 +87,7 @@ export default function CheckTodo({
             <span
               className={cn(
                 'overflow-hidden text-ellipsis whitespace-nowrap break-words text-12M text-gs500 2xl:text-14M',
-                goal?.color ? `text-${goal.color}` : 'text-slate500',
+                goalColor[goal?.color || 'default'],
               )}
             >
               {goal?.title}

--- a/src/components/common/todo/CheckTodo.tsx
+++ b/src/components/common/todo/CheckTodo.tsx
@@ -62,6 +62,7 @@ export default function CheckTodo({
         className={cn(
           'group flex w-full cursor-pointer items-center justify-center gap-2 border-b border-dashed border-gs200 p-2 text-gsBk 2xl:gap-3 2xl:px-3 2xl:py-4',
           { 'hover:bg-slate50 hover:text-slate700': !done },
+          { 'bg-slate50 text-slate700': isMenuOpen },
         )}
         onClick={() => {
           if (onCheck) onCheck();
@@ -104,9 +105,10 @@ export default function CheckTodo({
         </p>
         <IconButton
           className={cn(
-            'flex-none rounded-2xl bg-gs50 text-slate500 group-hover:bg-gs00',
+            'flex-none rounded-2xl bg-gs00 text-slate500 group-hover:bg-gs00',
             {
-              'invisible pl-1 group-hover:visible': noteId === null,
+              'opacity-100': isMenuOpen,
+              'opacity-0 group-hover:opacity-100': !isMenuOpen,
             },
           )}
           icon={noteIcon}
@@ -117,7 +119,13 @@ export default function CheckTodo({
         />
         <div className="relative">
           <IconButton
-            className="flex-none rounded-2xl bg-gs50 text-gs400 group-hover:bg-gs00 md:hidden md:group-hover:flex"
+            className={cn(
+              'flex-none rounded-2xl bg-gs00 text-gs400 transition-opacity',
+              {
+                'opacity-100': isMenuOpen,
+                'opacity-0 group-hover:opacity-100': !isMenuOpen,
+              },
+            )}
             icon={faEllipsisVertical}
             onClick={(e) => {
               e.stopPropagation();

--- a/src/components/todoCalendar/Calendar.tsx
+++ b/src/components/todoCalendar/Calendar.tsx
@@ -11,6 +11,7 @@ interface Props {
   calendarDivRef: React.RefObject<HTMLDivElement>;
   onDateChange: (date: Date) => void;
   onDropTodo: (date: string, todoId: number) => void;
+  onMonthChange: (year: number, month: number) => void;
 }
 
 /**
@@ -21,6 +22,7 @@ interface Props {
  * @param calendarDivRef 전체 캘린더의 ref
  * @param onDateChange 선택 날짜 변경 함수
  * @param onDropTodo 장바구니에서 드래그&드롭 한 요소 드롭 적용 함수
+ * @param onMonthChange 달력의 달 변경 함수
  */
 export default function Calendar({
   todos,
@@ -29,12 +31,17 @@ export default function Calendar({
   calendarDivRef,
   onDateChange,
   onDropTodo,
+  onMonthChange,
 }: Props) {
   const calendarRef = useRef<FullCalendar>(null);
   return (
     <div ref={calendarDivRef}>
       {isCalendarLoaded && (
-        <CalendarHeader calendarRef={calendarRef} onDateChange={onDateChange} />
+        <CalendarHeader
+          calendarRef={calendarRef}
+          onDateChange={onDateChange}
+          onMonthChange={onMonthChange}
+        />
       )}
       <CalendarBody
         todos={todos}
@@ -42,6 +49,7 @@ export default function Calendar({
         onDateChange={onDateChange}
         calendarRef={calendarRef}
         onDropTodo={onDropTodo}
+        onMonthChange={onMonthChange}
       />
     </div>
   );

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -60,6 +60,7 @@ interface Props {
   onDateChange: (date: Date) => void;
   calendarRef: React.RefObject<FullCalendar>;
   onDropTodo: (date: string, todoId: number) => void;
+  onMonthChange: (year: number, month: number) => void;
 }
 
 export default function CalendarBody({
@@ -68,6 +69,7 @@ export default function CalendarBody({
   onDateChange,
   calendarRef,
   onDropTodo,
+  onMonthChange,
 }: Props) {
   /**
    * 셀에 클래스 부여
@@ -101,7 +103,7 @@ export default function CalendarBody({
   /**
    * 날짜 셀 크기 업데이트
    */
-  const handleDayCellMount = (info: { el: HTMLElement }) => {
+  const handleDayCellMount = () => {
     // 반응형에 맞춰 셀 크기 업데이트
     const updateCellSize = () => {
       const cell = document.querySelector('.fc-daygrid-day');
@@ -130,28 +132,35 @@ export default function CalendarBody({
         });
       }
     };
-    // 숨겨진 이벤트 개수 표시
-    const updateMoreCount = () => {
-      requestAnimationFrame(() => {
-        const events = info.el.querySelectorAll('.fc-event');
 
-        // 숨겨진 이벤트 개수 계산
+    updateCellSize();
+
+    window.addEventListener('resize', updateCellSize);
+
+    return () => {
+      window.removeEventListener('resize', updateCellSize);
+    };
+  };
+
+  const updateMoreCount = () => {
+    requestAnimationFrame(() => {
+      document.querySelectorAll('.fc-daygrid-day').forEach((dayCell) => {
+        const events = dayCell.querySelectorAll('.fc-event');
         const hiddenEvents = Array.from(events).filter(
           (e) => (e as HTMLElement).offsetHeight === 0,
         ).length;
 
-        let moreCountEl = info.el.querySelector(
+        let moreCountEl = dayCell.querySelector(
           '.event-more-count',
         ) as HTMLElement;
         if (!moreCountEl) {
           moreCountEl = document.createElement('div');
           moreCountEl.className =
             'event-more-count absolute top-2 right-2 text-12SB text-gs500';
-          info.el.appendChild(moreCountEl);
+          dayCell.appendChild(moreCountEl);
         }
 
-        // 숨겨진 이벤트가 있으면 텍스트 추가, 없으면 숨김
-        const cellWidth = info.el.clientWidth;
+        const cellWidth = dayCell.clientWidth;
         if (hiddenEvents > 0) {
           if (cellWidth > 88) {
             moreCountEl.textContent = `+${hiddenEvents} more`;
@@ -163,24 +172,28 @@ export default function CalendarBody({
 
           moreCountEl.style.opacity = '1';
         } else {
+          moreCountEl.textContent = '';
           moreCountEl.style.opacity = '0';
         }
       });
-    };
-
-    updateCellSize();
-    updateMoreCount();
-
+    });
+  };
+  useEffect(() => {
     const observer = new ResizeObserver(updateMoreCount);
-    observer.observe(info.el);
-
-    window.addEventListener('resize', updateCellSize);
+    document.querySelectorAll('.fc-daygrid-day').forEach((dayCell) => {
+      observer.observe(dayCell);
+    });
 
     return () => {
       observer.disconnect();
-      window.removeEventListener('resize', updateCellSize);
     };
-  };
+  }, []);
+
+  useEffect(() => {
+    if (todos.length > 0) {
+      updateMoreCount();
+    }
+  }, [todos]);
 
   /**
    * 사이드 바가 접히거나 펼쳐지면 캘린더 크기 재조정
@@ -210,7 +223,7 @@ export default function CalendarBody({
       initialView="dayGridMonth"
       events={todos.map((event) => ({
         ...event,
-        id: event.id.toString(),
+        id: event.todoId.toString(),
         className: goalColor[event.goal?.color || 'default'],
       }))}
       eventBorderColor="transparent"
@@ -234,6 +247,12 @@ export default function CalendarBody({
 
         onDropTodo(date, todoId);
         info.event.remove();
+      }}
+      datesSet={(info) => {
+        const newDate = new Date(info.view.currentStart);
+        const newYear = newDate.getFullYear();
+        const newMonth = newDate.getMonth() + 1;
+        onMonthChange(newYear, newMonth);
       }}
     />
   );

--- a/src/components/todoCalendar/CalendarHeader.tsx
+++ b/src/components/todoCalendar/CalendarHeader.tsx
@@ -52,7 +52,6 @@ export default function CalendarHeader({
     onDateChange(today);
     const calendarApi = calendarRef.current?.getApi();
     calendarApi?.today();
-    // updateCurrentView();
   };
 
   /**
@@ -61,7 +60,6 @@ export default function CalendarHeader({
   const handlePrevMonthClick = () => {
     const calendarApi = calendarRef.current?.getApi();
     calendarApi?.prev();
-    // updateCurrentView();
   };
 
   /**
@@ -69,7 +67,6 @@ export default function CalendarHeader({
    */ const handleNextMonthClick = () => {
     const calendarApi = calendarRef.current?.getApi();
     calendarApi?.next();
-    // updateCurrentView();
   };
 
   return (

--- a/src/components/todoCalendar/CalendarHeader.tsx
+++ b/src/components/todoCalendar/CalendarHeader.tsx
@@ -1,12 +1,13 @@
 import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
 import FullCalendar from '@fullcalendar/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import IconButton from '../common/button/IconButton';
 import Button from '../common/button/Button';
 
 interface Props {
   calendarRef: React.RefObject<FullCalendar>;
   onDateChange: (date: Date) => void;
+  onMonthChange: (year: number, month: number) => void;
 }
 
 /**
@@ -16,18 +17,30 @@ interface Props {
  * @param calendarRef 달력
  * @param onDateChange 선택 날짜 변경
  */
-export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
+export default function CalendarHeader({
+  calendarRef,
+  onDateChange,
+  onMonthChange,
+}: Props) {
   // 헤더에 있는 현재 달력의 달을 보여주기 위함
   const [viewMonth, setViewMonth] = useState<Date>(new Date());
 
-  /**
-   * 현재 달력 위치의 날짜로 업데이트
-   */
-  const updateCurrentView = () => {
+  useEffect(() => {
     const calendarApi = calendarRef.current?.getApi();
-    const currentDate = calendarApi?.getDate() ?? new Date();
-    setViewMonth(currentDate);
-  };
+    if (!calendarApi) return undefined;
+
+    const handleDatesSet = () => {
+      const newDate = new Date(calendarApi.getDate());
+      setViewMonth(newDate);
+      onMonthChange(newDate.getFullYear(), newDate.getMonth() + 1);
+    };
+
+    calendarApi.on('datesSet', handleDatesSet);
+
+    return () => {
+      calendarApi.off('datesSet', handleDatesSet);
+    };
+  }, [calendarRef, onMonthChange]);
 
   /**
    * today 버튼을 클릭했을 때
@@ -39,7 +52,7 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
     onDateChange(today);
     const calendarApi = calendarRef.current?.getApi();
     calendarApi?.today();
-    updateCurrentView();
+    // updateCurrentView();
   };
 
   /**
@@ -48,7 +61,7 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
   const handlePrevMonthClick = () => {
     const calendarApi = calendarRef.current?.getApi();
     calendarApi?.prev();
-    updateCurrentView();
+    // updateCurrentView();
   };
 
   /**
@@ -56,7 +69,7 @@ export default function CalendarHeader({ calendarRef, onDateChange }: Props) {
    */ const handleNextMonthClick = () => {
     const calendarApi = calendarRef.current?.getApi();
     calendarApi?.next();
-    updateCurrentView();
+    // updateCurrentView();
   };
 
   return (

--- a/src/components/todoCalendar/CreateTodo.tsx
+++ b/src/components/todoCalendar/CreateTodo.tsx
@@ -15,7 +15,9 @@ const createTodoSchema = z.object({
     .nonempty('제목을 입력해주세요')
     .max(30, '제목은 30자 이하여야 합니다'),
   goal: z.any().nullable().optional(),
-  date: z.date().optional(),
+  date: z
+    .date({ required_error: '날짜를 선택해주세요' })
+    .refine((value) => value !== null, { message: '날짜를 선택해주세요' }),
 });
 
 export type TodoFormValues = z.infer<typeof createTodoSchema>;

--- a/src/components/todoCalendar/CreateTodo.tsx
+++ b/src/components/todoCalendar/CreateTodo.tsx
@@ -6,8 +6,8 @@ import DropDownInput from '@/components/common/input/DropDownInput';
 import DateInput from '../common/input/DateInput';
 import cn from '@/utils/cn';
 import Button from '../common/button/Button';
-import { getErrorMessage } from '@/constants/errorMessages';
 import { useGoals } from '@/hooks/useGoals';
+import { useAddTodo } from '@/hooks/useTodos';
 
 const createTodoSchema = z.object({
   title: z
@@ -34,24 +34,15 @@ export default function CreateTodo({
   savedValues,
 }: Props) {
   const { data: goalList, isLoading } = useGoals();
+  const { mutate: addTodo } = useAddTodo();
 
   // TODO:: tanstack query 도입 후 mutation 사용으로 변경
   const onSubmit = async (formData: TodoFormValues) => {
-    try {
-      const response = await fetch('/api/todos', {
-        method: 'POST',
-        body: JSON.stringify({
-          title: formData.title,
-          goalId: formData.goal?.goalId,
-          date: formData.date?.toISOString().split('T')[0] || null,
-        }),
-      });
-
-      if (!response.ok) throw new Error(getErrorMessage(response.status));
-      onCloseModal();
-    } catch (error) {
-      console.log('할 일 생성 중 오류 발생', error);
-    }
+    addTodo(formData, {
+      onSuccess: () => {
+        onCloseModal();
+      },
+    });
   };
 
   const {

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -4,58 +4,13 @@ import React, { useEffect, useRef, useState } from 'react';
 import Calendar from './Calendar';
 
 import TodoList from './TodoList';
-import { Basket, Todo } from '@/types/todos';
+import { Basket } from '@/types/todos';
 import TodoModal from './TodoModal';
 import Loading from '../common/Loading';
+import { useMonthlyTodos } from '@/hooks/useMonthlyTodos';
 
 // import Loading from '../common/Loading';
 // import TodoBasket from './TodoBasket';
-
-const initialTodos = [
-  {
-    id: 1,
-    title: '할일 1',
-    date: '2025-02-03',
-    goal: null,
-    done: true,
-  },
-  {
-    id: 2,
-    title: '할일 2',
-    date: '2025-02-10',
-    goal: {
-      goalId: 1,
-      title: '강의 듣기',
-      color: 'goal01',
-      createdAt: '2025-02-26T02:49:55.691312Z',
-    },
-    done: true,
-  },
-  {
-    id: 3,
-    title: '할일 3',
-    date: '2025-02-07',
-    goal: {
-      goalId: 2,
-      title: '목표 2',
-      color: 'goal02',
-      createdAt: '2025-02-26T02:49:55.691312Z',
-    },
-    done: true,
-  },
-  {
-    id: 4,
-    title: '할일 4',
-    date: '2025-02-20',
-    goal: {
-      goalId: 3,
-      title: '목표 3',
-      color: 'goal02',
-      createdAt: '2025-02-26T02:49:55.691312Z',
-    },
-    done: true,
-  },
-];
 
 const initialBasketList = [
   { id: 101, title: '코딩강의 듣기', goal: null },
@@ -87,12 +42,22 @@ const initialBasketList = [
 
 export default function TodoCalendar() {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
-  const [todos, setTodos] = useState<Todo[]>(initialTodos);
+  const [currentYear, setCurrentYear] = useState<number>(
+    new Date().getFullYear(),
+  );
+  const [currentMonth, setCurrentMonth] = useState<number>(
+    new Date().getMonth() + 1,
+  );
   const [basketList, setBasketList] = useState<Basket[]>(initialBasketList);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [calendarHeight, setCalendarHeight] = useState<number>(0);
   const [isCalendarLoaded, setIsCalendarLoaded] = useState(false);
   const calendarRef = useRef<HTMLDivElement>(null);
+  const {
+    data: todos,
+    isLoading,
+    error,
+  } = useMonthlyTodos(currentYear, currentMonth);
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
@@ -110,18 +75,20 @@ export default function TodoCalendar() {
    * 할 일의 체크박스 상태 변경
    */
   const handleToggleTodo = (id: number) => {
-    setTodos((prev) =>
-      prev.map((todo) =>
-        todo.id === id ? { ...todo, done: !todo.done } : todo,
-      ),
-    );
+    console.log('toggle', id);
+    // setTodos((prev) =>
+    //   prev.map((todo) =>
+    //     todo.id === id ? { ...todo, done: !todo.done } : todo,
+    //   ),
+    // );
   };
 
   /**
    * 할 일 삭제
    */
   const handleDeleteTodo = (id: number) => {
-    setTodos((prev) => prev.filter((todo) => todo.id !== id));
+    console.log('delete', id);
+    // setTodos((prev) => prev.filter((todo) => todo.id !== id));
   };
 
   /**
@@ -145,14 +112,14 @@ export default function TodoCalendar() {
   const handleDropTodo = (date: string, todoId: number) => {
     const draggedTodo = basketList.find((todo) => todo.id === todoId);
     if (!draggedTodo) return;
-    const newTodo: Todo = {
-      id: todoId,
-      title: draggedTodo.title,
-      date,
-      goal: draggedTodo.goal || null,
-      done: false,
-    };
-    setTodos((prev) => [...prev, newTodo]);
+    // const newTodo: Todo = {
+    //   id: todoId,
+    //   title: draggedTodo.title,
+    //   date,
+    //   goal: draggedTodo.goal || null,
+    //   done: false,
+    // };
+    // setTodos((prev) => [...prev, newTodo]);
     setBasketList((prev) => prev.filter((todo) => todo.id !== todoId));
   };
 
@@ -173,17 +140,29 @@ export default function TodoCalendar() {
     return undefined;
   }, []);
 
-  return (
+  return error ? (
+    <div>
+      <p className="text-red-500">데이터를 불러오는 중 오류 발생</p>
+    </div>
+  ) : (
     <div className="flex flex-col justify-center gap-4 md:flex-row">
       <div className="flex-1">
-        <Calendar
-          todos={todos}
-          selectedDate={selectedDate}
-          onDateChange={setSelectedDate}
-          onDropTodo={handleDropTodo}
-          calendarDivRef={calendarRef}
-          isCalendarLoaded={isCalendarLoaded}
-        />
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <Calendar
+            todos={todos}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            onDropTodo={handleDropTodo}
+            calendarDivRef={calendarRef}
+            isCalendarLoaded={isCalendarLoaded}
+            onMonthChange={(year, month) => {
+              setCurrentYear(year);
+              setCurrentMonth(month);
+            }}
+          />
+        )}
         {!isCalendarLoaded && <Loading />}
       </div>
       {isCalendarLoaded && (
@@ -205,14 +184,14 @@ export default function TodoCalendar() {
         </div>
       )}
       {/* {isCalendarReady && (
-        <TodoBasket
-          basketList={basketList}
-          onDeleteBasketTodo={handleDeleteBasketTodo}
-          onDeleteAllBasket={handleDeleteAllBasket}
-        />
-      )}
+          <TodoBasket
+            basketList={basketList}
+            onDeleteBasketTodo={handleDeleteBasketTodo}
+            onDeleteAllBasket={handleDeleteAllBasket}
+          />
+        )}
 
-      )} */}
+        )} */}
       {isModalOpen && (
         <TodoModal
           selectedDate={selectedDate}

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -7,7 +7,7 @@ import TodoList from './TodoList';
 import { Basket } from '@/types/todos';
 import TodoModal from './TodoModal';
 import Loading from '../common/Loading';
-import { useMonthlyTodos } from '@/hooks/useMonthlyTodos';
+import { useDailyTodos, useMonthlyTodos } from '@/hooks/useTodos';
 
 // import Loading from '../common/Loading';
 // import TodoBasket from './TodoBasket';
@@ -53,11 +53,18 @@ export default function TodoCalendar() {
   const [calendarHeight, setCalendarHeight] = useState<number>(0);
   const [isCalendarLoaded, setIsCalendarLoaded] = useState(false);
   const calendarRef = useRef<HTMLDivElement>(null);
+
+  // 한 달 단위 할 일
   const {
-    data: todos,
+    data: monthlyTodos,
     isLoading,
     error,
   } = useMonthlyTodos(currentYear, currentMonth);
+
+  // 하루 단위 할 일
+  const { data: dailyTodos } = useDailyTodos(
+    selectedDate.toLocaleDateString('sv-SE'),
+  );
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
@@ -151,7 +158,7 @@ export default function TodoCalendar() {
           <Loading />
         ) : (
           <Calendar
-            todos={todos}
+            todos={monthlyTodos}
             selectedDate={selectedDate}
             onDateChange={setSelectedDate}
             onDropTodo={handleDropTodo}
@@ -173,11 +180,7 @@ export default function TodoCalendar() {
           <TodoList
             selectedDate={selectedDate}
             onToggleTodo={handleToggleTodo}
-            todos={todos.filter(
-              (todo) =>
-                new Date(todo.date).toDateString() ===
-                selectedDate.toDateString(),
-            )}
+            todos={dailyTodos}
             onDeleteTodo={handleDeleteTodo}
             onOpenModal={handleOpenModal}
           />

--- a/src/components/todoCalendar/TodoListItem.tsx
+++ b/src/components/todoCalendar/TodoListItem.tsx
@@ -22,15 +22,15 @@ export default function TodoListItem({
   return (
     <ul>
       {todoList.map((todo) => (
-        <li key={todo.id} className="last:border-0">
+        <li key={todo.todoId} className="last:border-0">
           <CheckTodo
-            id={todo.id}
+            id={todo.todoId}
             title={todo.title}
             goal={todo.goal}
             done={todo.done}
             noteId={null}
-            onCheck={() => onToggleTodo(todo.id)}
-            onDelete={() => onDeleteTodo(todo.id)}
+            onCheck={() => onToggleTodo(todo.todoId)}
+            onDelete={() => onDeleteTodo(todo.todoId)}
           />
         </li>
       ))}

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,3 +1,4 @@
 export const QUERY_KEY = {
   GOALS: 'GOALS',
+  MONTHLY_TODOS: 'MONTHLY_TODOS',
 } as const;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,4 +1,5 @@
 export const QUERY_KEY = {
   GOALS: 'GOALS',
   MONTHLY_TODOS: 'MONTHLY_TODOS',
+  DAILY_TODOS: 'DAILY_TODOS',
 } as const;

--- a/src/hooks/useMonthlyTodos.ts
+++ b/src/hooks/useMonthlyTodos.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { getErrorMessage } from '@/constants/errorMessages';
+import { QUERY_KEY } from '@/constants/queryKey';
+import { Todo } from '@/types/todos';
+
+const fetchMonthlyTodos = async (year: number, month: number) => {
+  const formattedMonth = String(month).padStart(2, '0');
+  const res = await fetch(`api/todos?year=${year}&month=${formattedMonth}`);
+  if (!res.ok) throw new Error(getErrorMessage(res.status));
+  return res.json();
+};
+
+export const useMonthlyTodos = (year: number, month: number) => {
+  return useQuery<Todo[]>({
+    queryKey: [QUERY_KEY.MONTHLY_TODOS, { year, month }],
+    queryFn: () => fetchMonthlyTodos(year, month),
+    initialData: [],
+    retry: false,
+    throwOnError: false,
+  });
+};

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -26,7 +26,7 @@ const addTodo = async (formData: TodoFormValues) => {
       body: JSON.stringify({
         title: formData.title,
         goalId: formData.goal?.goalId,
-        date: formData.date?.toISOString().split('T')[0] || null,
+        date: formData.date.toLocaleDateString('sv-SE'),
       }),
     });
 

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -5,7 +5,15 @@ import { Todo } from '@/types/todos';
 
 const fetchMonthlyTodos = async (year: number, month: number) => {
   const formattedMonth = String(month).padStart(2, '0');
-  const res = await fetch(`api/todos?year=${year}&month=${formattedMonth}`);
+  const res = await fetch(
+    `api/todos/monthly?year=${year}&month=${formattedMonth}`,
+  );
+  if (!res.ok) throw new Error(getErrorMessage(res.status));
+  return res.json();
+};
+
+const fetchDaliyTodos = async (date: string) => {
+  const res = await fetch(`api/todos/daily?date=${date}`);
   if (!res.ok) throw new Error(getErrorMessage(res.status));
   return res.json();
 };
@@ -14,6 +22,16 @@ export const useMonthlyTodos = (year: number, month: number) => {
   return useQuery<Todo[]>({
     queryKey: [QUERY_KEY.MONTHLY_TODOS, { year, month }],
     queryFn: () => fetchMonthlyTodos(year, month),
+    initialData: [],
+    retry: false,
+    throwOnError: false,
+  });
+};
+
+export const useDailyTodos = (date: string) => {
+  return useQuery<Todo[]>({
+    queryKey: [QUERY_KEY.DAILY_TODOS, date],
+    queryFn: () => fetchDaliyTodos(date),
     initialData: [],
     retry: false,
     throwOnError: false,

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,7 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getErrorMessage } from '@/constants/errorMessages';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { Todo } from '@/types/todos';
+import { TodoFormValues } from '@/components/todoCalendar/CreateTodo';
 
 const fetchMonthlyTodos = async (year: number, month: number) => {
   const formattedMonth = String(month).padStart(2, '0');
@@ -16,6 +17,26 @@ const fetchDaliyTodos = async (date: string) => {
   const res = await fetch(`api/todos/daily?date=${date}`);
   if (!res.ok) throw new Error(getErrorMessage(res.status));
   return res.json();
+};
+
+const addTodo = async (formData: TodoFormValues) => {
+  try {
+    const response = await fetch('/api/todos', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: formData.title,
+        goalId: formData.goal?.goalId,
+        date: formData.date?.toISOString().split('T')[0] || null,
+      }),
+    });
+
+    if (!response.ok) throw new Error(getErrorMessage(response.status));
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log('할 일 생성 중 오류 발생', error);
+    throw error;
+  }
 };
 
 export const useMonthlyTodos = (year: number, month: number) => {
@@ -35,5 +56,31 @@ export const useDailyTodos = (date: string) => {
     initialData: [],
     retry: false,
     throwOnError: false,
+  });
+};
+
+export const useAddTodo = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (formData: TodoFormValues) => addTodo(formData),
+    onSuccess: (newTodo) => {
+      const { date } = newTodo;
+      const year = new Date(date).getFullYear();
+      const month = new Date(date).getMonth() + 1;
+
+      queryClient.setQueryData(
+        [QUERY_KEY.DAILY_TODOS, date],
+        (oldData: Todo[]) => {
+          if (!oldData) return [newTodo];
+          return [...oldData, newTodo];
+        },
+      );
+
+      // 한 달 단위의 캐시는 무효화 -> 최신 데이터 유지
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.MONTHLY_TODOS, { year, month }],
+      });
+    },
   });
 };

--- a/src/types/todos.d.ts
+++ b/src/types/todos.d.ts
@@ -7,7 +7,7 @@ export interface Todo {
   createdAt: string;
   title: string;
   done: boolean;
-  goal: Goal;
+  goal: Goal | null;
 }
 
 export interface Basket {

--- a/src/types/todos.d.ts
+++ b/src/types/todos.d.ts
@@ -1,11 +1,13 @@
 import { Goal } from './goals';
 
 export interface Todo {
-  id: number;
-  title: string;
+  todoId: number;
+  noteId: number | null;
   date: string;
-  goal: Goal | null;
+  createdAt: string;
+  title: string;
   done: boolean;
+  goal: Goal;
 }
 
 export interface Basket {


### PR DESCRIPTION
## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

`해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`
> 할 일 조회
- 현재 캘린더가 렌더링 된 달을 추적하여 header 값과 api로 호출하는 값 전달.
- 한 달 단위와 하루 단위의 할 일을 각각 query로 관리
- 캘린더에는 한 달 단위의 data, 단일 날짜 할 일 조회에서는 하루 단위의 data 사용
- 현재 백엔드 api에서 error message를 보내도 200으로 보내주기 때문에 router에서 error 처리함

> 할 일 생성
- mutation 사용
- 각 데이터를 최신상태로 유지하기 위해 mutation으로 하루 단위에 할 일을 추가하고,
- 한달 단위는 무효화하여 관리함


## 패키지 설치내용 📦
```bash
pnpm add @tanstack/react-query-devtools
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 일간 및 월간 할일 조회를 위한 API 경로가 추가되어 할일 데이터가 보다 동적으로 제공됩니다.
	- 캘린더에 월 변경 이벤트가 도입되어 선택된 월에 맞춘 할일 데이터가 자동 갱신됩니다.
	- 할일 추가를 위한 새로운 훅이 도입되어 할일 생성 프로세스가 간소화되었습니다.
	- 새로운 `@tanstack/react-query-devtools` 패키지가 도입되어 디버깅 기능이 향상되었습니다.
- **UI 개선**
	- 할일 목표 색상 표기와 내비게이션 메뉴의 레이어 순서가 개선되어 인터페이스 가독성이 향상되었습니다.
	- 할일 생성 시 날짜 선택 필드 검증이 강화되어 입력 오류가 줄어듭니다.
- **기타**
	- 최신 개발 도구 종속성이 업데이트되었습니다.
	- 새로운 쿼리 키가 추가되어 데이터 관리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->