### PR TITLE
[CAN-21/Feat] 대시보드 목표별 할일 UI 개발

### DIFF
--- a/src/app/(member)/page.tsx
+++ b/src/app/(member)/page.tsx
@@ -4,6 +4,7 @@ import TodayProgress from '@/components/dashboard/todayProgress/TodayProgress';
 import TodayList from '@/components/dashboard/todayList/TodayList';
 import TodayProgressSkeleton from '@/components/dashboard/todayProgress/TodayProgressSkeleton';
 import TodayProgressError from '@/components/dashboard/todayProgress/TodayProgressError';
+import GoalList from '@/components/dashboard/goalList/GoalList';
 
 export default function Page() {
   return (
@@ -16,8 +17,11 @@ export default function Page() {
           </Suspense>
         </ErrorBoundary>
       </section>
-      <section className="flex flex-col" />
-      <section className="flex" />
+      <section className="flex flex-col">
+        <p className="text-16SB 2xl:text-18SB">목표별 할일</p>
+        <GoalList />
+      </section>
+      <section className="flex gap-8" />
     </div>
   );
 }

--- a/src/app/(member)/page.tsx
+++ b/src/app/(member)/page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
         </ErrorBoundary>
       </section>
       <section className="flex flex-col">
-        <p className="text-16SB 2xl:text-18SB">목표별 할일</p>
+        <p className="mb-3 text-16SB 2xl:text-18SB">목표별 할일</p>
         <GoalList />
       </section>
       <section className="flex gap-8" />

--- a/src/components/common/navbar/navGoal/NavGoalItem.tsx
+++ b/src/components/common/navbar/navGoal/NavGoalItem.tsx
@@ -22,7 +22,7 @@ export default function NavGoalItem({ id, title, color, isSelected }: Props) {
         },
       )}
     >
-      <span className={`ml-2 h-2 w-2 rounded-md ${c}`} />
+      <span className={`ml-2 size-2 flex-none rounded-md ${c}`} />
       <span className="text-overflow h-4 text-12R 2xl:h-5 2xl:text-14R">
         {title}
       </span>

--- a/src/components/common/todo/SimpleTodoSkeleton.tsx
+++ b/src/components/common/todo/SimpleTodoSkeleton.tsx
@@ -6,6 +6,7 @@ export default function SimpleTodoSkeleton({ repeat = 4 }: Props) {
     <div
       key={e}
       className="my-2 block h-6 w-full flex-none animate-pulse rounded-md bg-gs100 2xl:h-7"
+      aria-busy
     />
   ));
 }

--- a/src/components/common/todo/SimpleTodoSkeleton.tsx
+++ b/src/components/common/todo/SimpleTodoSkeleton.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  repeat?: number;
+}
+export default function SimpleTodoSkeleton({ repeat = 4 }: Props) {
+  return Array.from({ length: repeat }, (_, i) => i + 1).map((e) => (
+    <div
+      key={e}
+      className="my-2 block h-6 w-full flex-none animate-pulse rounded-md bg-gs100 2xl:h-7"
+    />
+  ));
+}

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -7,10 +7,13 @@ import { Goal } from '@/types/goals';
 import SimpleTodo from '@/components/common/todo/SimpleTodo';
 import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
 import GoalTabSkeleton from './GoalTabSkeleton';
+import { useDragScroll } from '@/hooks/useDragScroll';
 
 export default function GoalList() {
   const { data: goalTabs, isFetching: isGoalTabsFetching } = useGoals();
   const [selectedGoalIndex, setSelectedGoalIndex] = useState<number>(0);
+  const { scrollRef, handlePointerDown, handlePointerMove, handlePointerUp } =
+    useDragScroll<HTMLDivElement>();
 
   if (!isGoalTabsFetching && goalTabs.length === 0)
     return (
@@ -21,7 +24,14 @@ export default function GoalList() {
 
   return (
     <>
-      <div className="flex w-full overflow-x-scroll [&::-webkit-scrollbar]:hidden">
+      <div
+        ref={scrollRef}
+        className="flex w-full overflow-x-scroll [&::-webkit-scrollbar]:hidden"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+      >
         {isGoalTabsFetching && <GoalTabSkeleton />}
         {!isGoalTabsFetching &&
           goalTabs.map((goal: Goal, index: number) => (

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -1,25 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useGoals } from '@/hooks/useGoals';
 import GoalTab from './GoalTab';
 import { Goal } from '@/types/goals';
 import SimpleTodo from '@/components/common/todo/SimpleTodo';
+import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
+import GoalTabSkelton from './GoalTabSkelton';
 
 export default function GoalList() {
-  const { data: goalList, isFetching } = useGoals();
+  const { data: goalTabs, isFetching: isGoalTabsFetching } = useGoals();
+  const [selectedGoalIndex, setSelectedGoalIndex] = useState<number>(0);
 
-  const [selectedGoalId, setSelectedGoalId] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (goalList && goalList.length > 0) {
-      setSelectedGoalId(goalList[0].goalId);
-    }
-  }, [goalList]);
-
-  if (isFetching) return <div>fetching...</div>;
-
-  if (goalList.length === 0)
+  if (goalTabs.length === 0)
     <div className="flex size-full min-h-60 items-center justify-center rounded-2xl border-2 border-dashed border-gs200 bg-gs50 text-14M text-gs400 2xl:rounded-[20px]">
       왼쪽 사이드바에서 새로운 목표를 추가해주세요.
     </div>;
@@ -27,30 +20,41 @@ export default function GoalList() {
   return (
     <>
       <div className="flex w-full overflow-x-scroll [&::-webkit-scrollbar]:hidden">
-        {goalList.map((goal: Goal) => (
-          <GoalTab
-            key={goal.goalId}
-            title={goal.title}
-            isSelected={goal.goalId === selectedGoalId}
-            onSelect={() => setSelectedGoalId(goal.goalId)}
-          />
-        ))}
+        {isGoalTabsFetching && <GoalTabSkelton />}
+        {!isGoalTabsFetching &&
+          goalTabs.map((goal: Goal, index: number) => (
+            <GoalTab
+              key={goal.goalId}
+              title={goal.title}
+              isSelected={index === selectedGoalIndex}
+              onSelect={() => setSelectedGoalIndex(index)}
+            />
+          ))}
       </div>
       <div className="flex w-full flex-col gap-6 rounded-b-lg bg-gs00 px-6 py-4 md:flex-row">
         <section className="flex flex-col gap-3 md:flex-[3]">
           <p className="text-14SB">할일</p>
           <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
-            {Array.from({ length: 5 }, (_, i) => i).map((e) => (
-              <SimpleTodo key={e} title="hihihi" done={false} noteId={3} />
-            ))}
+            {isGoalTabsFetching && <SimpleTodoSkeleton />}
+            {!isGoalTabsFetching &&
+              /** TODO :: 목표 데이터 받아오는 fetch, data로 변경 */
+              Array.from({ length: 5 }, (_, i) => i).map((e) => (
+                <SimpleTodo key={e} title="hihihi" done={false} noteId={3} />
+              ))}
           </div>
         </section>
         <section className="flex flex-col gap-3 md:flex-[2]">
           <p className="text-14SB">완료</p>
           <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
-            <span className="relative block w-full text-center text-14M text-gs500 md:top-[70px] 2xl:top-[78px]">
-              완료된 할일이 없습니다.
-            </span>
+            {isGoalTabsFetching && <SimpleTodoSkeleton />}
+            {
+              /** TODO :: 데이터 받아올때 변경 */
+              !isGoalTabsFetching && (
+                <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
+                  완료된 할일이 없습니다.
+                </span>
+              )
+            }
           </div>
         </section>
       </div>

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -3,19 +3,14 @@
 import { useState } from 'react';
 import { useGoals } from '@/hooks/useGoals';
 import GoalTab from './GoalTab';
-import { Goal } from '@/types/goals';
 import SimpleTodo from '@/components/common/todo/SimpleTodo';
 import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
-import GoalTabSkeleton from './GoalTabSkeleton';
-import { useDragScroll } from '@/hooks/useDragScroll';
 
 export default function GoalList() {
-  const { data: goalTabs, isFetching: isGoalTabsFetching } = useGoals();
+  const { data: goals, isFetching: isGoalsFetching } = useGoals();
   const [selectedGoalIndex, setSelectedGoalIndex] = useState<number>(0);
-  const { scrollRef, handlePointerDown, handlePointerMove, handlePointerUp } =
-    useDragScroll<HTMLDivElement>();
 
-  if (!isGoalTabsFetching && goalTabs.length === 0)
+  if (!isGoalsFetching && goals.length === 0)
     return (
       <div className="flex size-full min-h-60 items-center justify-center rounded-2xl border-2 border-dashed border-gs200 bg-gs50 text-14M text-gs400 2xl:rounded-[20px]">
         왼쪽 사이드바에서 새로운 목표를 추가해주세요.
@@ -24,31 +19,18 @@ export default function GoalList() {
 
   return (
     <>
-      <div
-        ref={scrollRef}
-        className="flex w-full overflow-x-scroll [&::-webkit-scrollbar]:hidden"
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerLeave={handlePointerUp}
-      >
-        {isGoalTabsFetching && <GoalTabSkeleton />}
-        {!isGoalTabsFetching &&
-          goalTabs.map((goal: Goal, index: number) => (
-            <GoalTab
-              key={goal.goalId}
-              title={goal.title}
-              isSelected={index === selectedGoalIndex}
-              onSelect={() => setSelectedGoalIndex(index)}
-            />
-          ))}
-      </div>
+      <GoalTab
+        isFetching={isGoalsFetching}
+        goals={goals}
+        selectedIndex={selectedGoalIndex}
+        onSelect={(index) => setSelectedGoalIndex(index)}
+      />
       <div className="flex w-full flex-col gap-6 rounded-b-lg bg-gs00 px-6 py-4 md:flex-row">
         <section className="flex flex-col gap-3 md:flex-[3]">
           <p className="text-14SB">할일</p>
           <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
-            {isGoalTabsFetching && <SimpleTodoSkeleton />}
-            {!isGoalTabsFetching &&
+            {isGoalsFetching && <SimpleTodoSkeleton />}
+            {!isGoalsFetching &&
               /** TODO :: 목표 데이터 받아오는 fetch, data로 변경 */
               Array.from({ length: 5 }, (_, i) => i).map((e) => (
                 <SimpleTodo key={e} title="hihihi" done={false} noteId={3} />
@@ -58,10 +40,10 @@ export default function GoalList() {
         <section className="flex flex-col gap-3 md:flex-[2]">
           <p className="text-14SB">완료</p>
           <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
-            {isGoalTabsFetching && <SimpleTodoSkeleton />}
+            {isGoalsFetching && <SimpleTodoSkeleton />}
             {
               /** TODO :: 데이터 받아올때 변경 */
-              !isGoalTabsFetching && (
+              !isGoalsFetching && (
                 <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
                   완료된 할일이 없습니다.
                 </span>

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useGoals } from '@/hooks/useGoals';
+import GoalTab from './GoalTab';
+import { Goal } from '@/types/goals';
+import SimpleTodo from '@/components/common/todo/SimpleTodo';
+
+export default function GoalList() {
+  const { data: goalList, isFetching } = useGoals();
+
+  const [selectedGoalId, setSelectedGoalId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (goalList && goalList.length > 0) {
+      setSelectedGoalId(goalList[0].goalId);
+    }
+  }, [goalList]);
+
+  if (isFetching) return <div>fetching...</div>;
+
+  if (goalList.length === 0)
+    <div className="flex size-full min-h-60 items-center justify-center rounded-2xl border-2 border-dashed border-gs200 bg-gs50 text-14M text-gs400 2xl:rounded-[20px]">
+      왼쪽 사이드바에서 새로운 목표를 추가해주세요.
+    </div>;
+
+  return (
+    <>
+      <div className="flex w-full overflow-x-scroll [&::-webkit-scrollbar]:hidden">
+        {goalList.map((goal: Goal) => (
+          <GoalTab
+            key={goal.goalId}
+            title={goal.title}
+            isSelected={goal.goalId === selectedGoalId}
+            onSelect={() => setSelectedGoalId(goal.goalId)}
+          />
+        ))}
+      </div>
+      <div className="flex w-full flex-col gap-6 rounded-b-lg bg-gs00 px-6 py-4 md:flex-row">
+        <section className="flex flex-col gap-3 md:flex-[3]">
+          <p className="text-14SB">할일</p>
+          <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
+            {Array.from({ length: 5 }, (_, i) => i).map((e) => (
+              <SimpleTodo key={e} title="hihihi" done={false} noteId={3} />
+            ))}
+          </div>
+        </section>
+        <section className="flex flex-col gap-3 md:flex-[2]">
+          <p className="text-14SB">완료</p>
+          <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
+            <span className="relative block w-full text-center text-14M text-gs500 md:top-[70px] 2xl:top-[78px]">
+              완료된 할일이 없습니다.
+            </span>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -6,21 +6,23 @@ import GoalTab from './GoalTab';
 import { Goal } from '@/types/goals';
 import SimpleTodo from '@/components/common/todo/SimpleTodo';
 import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
-import GoalTabSkelton from './GoalTabSkelton';
+import GoalTabSkeleton from './GoalTabSkeleton';
 
 export default function GoalList() {
   const { data: goalTabs, isFetching: isGoalTabsFetching } = useGoals();
   const [selectedGoalIndex, setSelectedGoalIndex] = useState<number>(0);
 
   if (goalTabs.length === 0)
-    <div className="flex size-full min-h-60 items-center justify-center rounded-2xl border-2 border-dashed border-gs200 bg-gs50 text-14M text-gs400 2xl:rounded-[20px]">
-      왼쪽 사이드바에서 새로운 목표를 추가해주세요.
-    </div>;
+    return (
+      <div className="flex size-full min-h-60 items-center justify-center rounded-2xl border-2 border-dashed border-gs200 bg-gs50 text-14M text-gs400 2xl:rounded-[20px]">
+        왼쪽 사이드바에서 새로운 목표를 추가해주세요.
+      </div>
+    );
 
   return (
     <>
       <div className="flex w-full overflow-x-scroll [&::-webkit-scrollbar]:hidden">
-        {isGoalTabsFetching && <GoalTabSkelton />}
+        {isGoalTabsFetching && <GoalTabSkeleton />}
         {!isGoalTabsFetching &&
           goalTabs.map((goal: Goal, index: number) => (
             <GoalTab

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -12,7 +12,7 @@ export default function GoalList() {
   const { data: goalTabs, isFetching: isGoalTabsFetching } = useGoals();
   const [selectedGoalIndex, setSelectedGoalIndex] = useState<number>(0);
 
-  if (goalTabs.length === 0)
+  if (!isGoalTabsFetching && goalTabs.length === 0)
     return (
       <div className="flex size-full min-h-60 items-center justify-center rounded-2xl border-2 border-dashed border-gs200 bg-gs50 text-14M text-gs400 2xl:rounded-[20px]">
         왼쪽 사이드바에서 새로운 목표를 추가해주세요.

--- a/src/components/dashboard/goalList/GoalTab.tsx
+++ b/src/components/dashboard/goalList/GoalTab.tsx
@@ -23,7 +23,7 @@ export default function GoalTab({ title, isSelected, onSelect }: Props) {
     <button
       type="button"
       className={cn(
-        'text-overflow relative h-9 flex-none rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
+        'relative h-9 flex-none overflow-hidden text-ellipsis whitespace-nowrap break-words rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
         { 'w-40 bg-gs00 text-gsBk md:w-56': isSelected },
         { 'w-20 border-x border-t border-gs200 md:w-32': !isSelected },
       )}

--- a/src/components/dashboard/goalList/GoalTab.tsx
+++ b/src/components/dashboard/goalList/GoalTab.tsx
@@ -1,41 +1,112 @@
 'use client';
 
-import { MouseEvent } from 'react';
+import { MouseEvent, useCallback } from 'react';
 import cn from '@/utils/cn';
+import { useDragScroll } from '@/hooks/useDragScroll';
+import { Goal } from '@/types/goals';
+import GoalTabSkeleton from './GoalTabSkeleton';
 
 interface Props {
-  title: string;
-  isSelected: boolean;
-  onSelect: () => void;
+  isFetching: boolean;
+  goals: Goal[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
 }
 
-export default function GoalTab({ title, isSelected, onSelect }: Props) {
-  const clickTab = (event: MouseEvent<HTMLButtonElement>) => {
-    onSelect();
-    event.currentTarget?.scrollIntoView({
-      behavior: 'smooth', // 부드러운 스크롤
-      inline: 'center', // 가로 중앙 정렬
-      block: 'nearest', // 세로 위치 유지
+export default function GoalTab({
+  isFetching,
+  goals,
+  selectedIndex,
+  onSelect,
+}: Props) {
+  const {
+    scrollRef,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseLeave,
+  } = useDragScroll<HTMLDivElement>();
+
+  const isSelected = useCallback(
+    (index: number) => {
+      return index === selectedIndex;
+    },
+    [selectedIndex],
+  );
+
+  if (isFetching) return <GoalTabSkeleton />;
+
+  /**
+   * @param event 목표 탭 클릭 이벤트
+   * 탭을 부모의 중앙으로 이동시켜주는 함수
+   */
+  const scrollToCenter = (event: MouseEvent<HTMLButtonElement>) => {
+    event.currentTarget.scrollIntoView({
+      behavior: 'smooth',
+      inline: 'center',
+      block: 'nearest',
     });
   };
 
+  /**
+   * @param event 목표 탭 클릭 이벤트
+   * @param index 클릭 이벤트가 발생한 목표 탭 인덱스
+   * onSelect함수 호출
+   * 클릭된 탭의 위치가 중앙에서 많이 벗어났을 경우 scrollToCenter함수 호출
+   */
+  const clickTab = (event: MouseEvent<HTMLButtonElement>, index: number) => {
+    onSelect(index);
+
+    const tab = event.currentTarget;
+    const tabContainer = tab.parentElement; // 탭들이 감싸진 부모 요소
+
+    if (!tabContainer) return;
+
+    const { left: containerLeft, width: containerWidth } =
+      tabContainer.getBoundingClientRect();
+    const { left: tabLeft, right: tabRight } = tab.getBoundingClientRect();
+
+    const containerCenter = containerLeft + containerWidth / 2; // 컨테이너 중앙
+    const tabCenter = (tabLeft + tabRight) / 2; // 클릭한 탭 중앙
+
+    const threshold = containerWidth * 0.4; // 어느 정도 벗어나야 움직일지 결정 (40% 정도)
+
+    if (Math.abs(tabCenter - containerCenter) > threshold) {
+      scrollToCenter(event);
+    }
+  };
+
   return (
-    <button
-      type="button"
-      className={cn(
-        'relative h-9 flex-none overflow-hidden text-ellipsis whitespace-nowrap break-words rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
-        { 'w-40 bg-gs00 text-gsBk md:w-56': isSelected },
-        { 'w-20 border-x border-t border-gs200 md:w-32': !isSelected },
-      )}
-      onClick={clickTab}
+    <div
+      ref={scrollRef}
+      className="flex w-full overflow-x-scroll [&::-webkit-scrollbar]:hidden"
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseLeave}
     >
-      <span
-        className={cn(
-          'invisible absolute left-0 top-1/2 h-6 w-[2px] -translate-y-1/2 bg-slate500',
-          { visible: isSelected },
-        )}
-      />
-      {title}
-    </button>
+      {goals.map((goal: Goal, index: number) => (
+        <button
+          type="button"
+          key={goal.goalId}
+          className={cn(
+            'relative h-9 flex-none overflow-hidden text-ellipsis whitespace-nowrap break-words rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
+            { 'w-40 bg-gs00 text-gsBk md:w-56': isSelected(index) },
+            {
+              'w-20 border-x border-t border-gs200 md:w-32': !isSelected(index),
+            },
+          )}
+          onClick={(e) => clickTab(e, index)}
+        >
+          <span
+            className={cn(
+              'invisible absolute left-0 top-1/2 h-6 w-[2px] -translate-y-1/2 bg-slate500',
+              { visible: isSelected(index) },
+            )}
+          />
+          {goal.title}
+        </button>
+      ))}
+    </div>
   );
 }

--- a/src/components/dashboard/goalList/GoalTab.tsx
+++ b/src/components/dashboard/goalList/GoalTab.tsx
@@ -23,8 +23,8 @@ export default function GoalTab({ title, isSelected, onSelect }: Props) {
     <button
       type="button"
       className={cn(
-        'text-overflow relative h-9 flex-none rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M transition-all duration-150',
-        { 'w-40 bg-gs00 md:w-56': isSelected },
+        'text-overflow relative h-9 flex-none rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
+        { 'w-40 bg-gs00 text-gsBk md:w-56': isSelected },
         { 'w-20 border-x border-t border-gs200 md:w-32': !isSelected },
       )}
       onClick={clickTab}

--- a/src/components/dashboard/goalList/GoalTab.tsx
+++ b/src/components/dashboard/goalList/GoalTab.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { MouseEvent } from 'react';
+import cn from '@/utils/cn';
+
+interface Props {
+  title: string;
+  isSelected: boolean;
+  onSelect: () => void;
+}
+
+export default function GoalTab({ title, isSelected, onSelect }: Props) {
+  const clickTab = (event: MouseEvent<HTMLButtonElement>) => {
+    onSelect();
+    event.currentTarget?.scrollIntoView({
+      behavior: 'smooth', // 부드러운 스크롤
+      inline: 'center', // 가로 중앙 정렬
+      block: 'nearest', // 세로 위치 유지
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'text-overflow relative h-9 flex-none rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M transition-all duration-150',
+        { 'w-40 bg-gs00 md:w-56': isSelected },
+        { 'w-20 border-x border-t border-gs200 md:w-32': !isSelected },
+      )}
+      onClick={clickTab}
+    >
+      <span
+        className={cn(
+          'invisible absolute left-0 top-1/2 h-6 w-[2px] -translate-y-1/2 bg-slate500',
+          { visible: isSelected },
+        )}
+      />
+      {title}
+    </button>
+  );
+}

--- a/src/components/dashboard/goalList/GoalTabSkeleton.tsx
+++ b/src/components/dashboard/goalList/GoalTabSkeleton.tsx
@@ -1,22 +1,26 @@
 import cn from '@/utils/cn';
 
 export default function GoalTabSkeleton() {
-  return Array.from({ length: 10 }, (_, i) => i).map((index) => (
-    <div
-      key={index}
-      className={cn(
-        'text-overflow relative h-9 flex-none rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
-        { 'w-40 bg-gs00 text-gsBk md:w-56': index === 0 },
-        { 'w-20 border-x border-t border-gs200 md:w-32': index > 0 },
-      )}
-      aria-busy
-    >
-      <span
-        className={cn(
-          'invisible absolute left-0 top-1/2 h-6 w-[2px] -translate-y-1/2 bg-slate500',
-          { visible: index === 0 },
-        )}
-      />
+  return (
+    <div className="flex w-full overflow-x-scroll [&::-webkit-scrollbar]:hidden">
+      {Array.from({ length: 10 }, (_, i) => i).map((index) => (
+        <div
+          key={index}
+          className={cn(
+            'text-overflow relative h-9 flex-none rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
+            { 'w-40 bg-gs00 text-gsBk md:w-56': index === 0 },
+            { 'w-20 border-x border-t border-gs200 md:w-32': index > 0 },
+          )}
+          aria-busy
+        >
+          <span
+            className={cn(
+              'invisible absolute left-0 top-1/2 h-6 w-[2px] -translate-y-1/2 bg-slate500',
+              { visible: index === 0 },
+            )}
+          />
+        </div>
+      ))}
     </div>
-  ));
+  );
 }

--- a/src/components/dashboard/goalList/GoalTabSkeleton.tsx
+++ b/src/components/dashboard/goalList/GoalTabSkeleton.tsx
@@ -1,19 +1,20 @@
 import cn from '@/utils/cn';
 
-export default function GoalTabSkelton() {
-  return Array.from({ length: 10 }, (_, i) => i).map((e) => (
+export default function GoalTabSkeleton() {
+  return Array.from({ length: 10 }, (_, i) => i).map((index) => (
     <div
-      key={e}
+      key={index}
       className={cn(
         'text-overflow relative h-9 flex-none rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
-        { 'w-40 bg-gs00 text-gsBk md:w-56': e === 0 },
-        { 'w-20 border-x border-t border-gs200 md:w-32': e > 0 },
+        { 'w-40 bg-gs00 text-gsBk md:w-56': index === 0 },
+        { 'w-20 border-x border-t border-gs200 md:w-32': index > 0 },
       )}
+      aria-busy
     >
       <span
         className={cn(
           'invisible absolute left-0 top-1/2 h-6 w-[2px] -translate-y-1/2 bg-slate500',
-          { visible: e === 0 },
+          { visible: index === 0 },
         )}
       />
     </div>

--- a/src/components/dashboard/goalList/GoalTabSkelton.tsx
+++ b/src/components/dashboard/goalList/GoalTabSkelton.tsx
@@ -1,0 +1,21 @@
+import cn from '@/utils/cn';
+
+export default function GoalTabSkelton() {
+  return Array.from({ length: 10 }, (_, i) => i).map((e) => (
+    <div
+      key={e}
+      className={cn(
+        'text-overflow relative h-9 flex-none rounded-t-lg bg-gs50 px-3 py-2 text-left text-14M text-gs400 transition-all duration-150',
+        { 'w-40 bg-gs00 text-gsBk md:w-56': e === 0 },
+        { 'w-20 border-x border-t border-gs200 md:w-32': e > 0 },
+      )}
+    >
+      <span
+        className={cn(
+          'invisible absolute left-0 top-1/2 h-6 w-[2px] -translate-y-1/2 bg-slate500',
+          { visible: e === 0 },
+        )}
+      />
+    </div>
+  ));
+}

--- a/src/components/dashboard/todayList/TodayList.tsx
+++ b/src/components/dashboard/todayList/TodayList.tsx
@@ -7,6 +7,7 @@ import { useSession } from 'next-auth/react';
 import SimpleTodo from '@/components/common/todo/SimpleTodo';
 import TodayListEmpty from './TodayListEmpty';
 import { useDailyTodos } from '@/hooks/useTodos';
+import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
 
 export default function TodayList() {
   const { data } = useSession();
@@ -44,21 +45,16 @@ export default function TodayList() {
         {formattedDate}
       </span>
       <div className="flex h-40 w-full flex-col overflow-y-auto 2xl:h-44">
-        {isFetching &&
-          Array.from({ length: 4 }, (_, i) => i + 1).map((e) => (
-            <div
-              key={e}
-              className="my-2 block h-6 w-full flex-none animate-pulse rounded-md bg-gs100 2xl:h-7"
+        {isFetching && <SimpleTodoSkeleton />}
+        {!isFetching &&
+          todayList.map((todo) => (
+            <SimpleTodo
+              key={todo.todoId}
+              title={todo.title}
+              done={false}
+              noteId={todo.noteId}
             />
           ))}
-        {todayList.map((todo) => (
-          <SimpleTodo
-            key={todo.todoId}
-            title={todo.title}
-            done={false}
-            noteId={todo.noteId}
-          />
-        ))}
         {!isFetching && !todayList.length && <TodayListEmpty />}
       </div>
     </div>

--- a/src/hooks/useDragScroll.ts
+++ b/src/hooks/useDragScroll.ts
@@ -1,0 +1,41 @@
+import { useRef, useState } from 'react';
+
+export function useDragScroll<T extends HTMLElement>() {
+  const scrollRef = useRef<T>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  /** 드래그 시작 */
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (!scrollRef.current) return;
+
+    setIsDragging(true);
+    setStartX(e.clientX - scrollRef.current.offsetLeft);
+    setScrollLeft(scrollRef.current.scrollLeft);
+
+    scrollRef.current.setPointerCapture(e.pointerId);
+  };
+
+  /** 드래그 중 */
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!isDragging || !scrollRef.current) return;
+
+    const x = e.clientX - scrollRef.current.offsetLeft;
+    const walk = (x - startX) * 1.5; // 드래그 속도 조절
+    scrollRef.current.scrollLeft = scrollLeft - walk;
+  };
+
+  /** 드래그 종료 */
+  const handlePointerUp = (e: React.PointerEvent) => {
+    setIsDragging(false);
+    scrollRef.current?.releasePointerCapture(e.pointerId);
+  };
+
+  return {
+    scrollRef,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+  };
+}

--- a/src/hooks/useDragScroll.ts
+++ b/src/hooks/useDragScroll.ts
@@ -7,18 +7,15 @@ export function useDragScroll<T extends HTMLElement>() {
   const [scrollLeft, setScrollLeft] = useState(0);
 
   /** 드래그 시작 */
-  const handlePointerDown = (e: React.PointerEvent) => {
+  const handleMouseDown = (e: React.MouseEvent) => {
     if (!scrollRef.current) return;
-
     setIsDragging(true);
     setStartX(e.clientX - scrollRef.current.offsetLeft);
     setScrollLeft(scrollRef.current.scrollLeft);
-
-    scrollRef.current.setPointerCapture(e.pointerId);
   };
 
   /** 드래그 중 */
-  const handlePointerMove = (e: React.PointerEvent) => {
+  const handleMouseMove = (e: React.MouseEvent) => {
     if (!isDragging || !scrollRef.current) return;
 
     const x = e.clientX - scrollRef.current.offsetLeft;
@@ -27,15 +24,25 @@ export function useDragScroll<T extends HTMLElement>() {
   };
 
   /** 드래그 종료 */
-  const handlePointerUp = (e: React.PointerEvent) => {
-    setIsDragging(false);
-    scrollRef.current?.releasePointerCapture(e.pointerId);
+  const handleMouseUp = () => {
+    if (isDragging) {
+      setIsDragging(false);
+    }
+  };
+
+  /** 마우스가 화면을 떠날 때 드래그 종료 */
+  const handleMouseLeave = () => {
+    if (isDragging) {
+      setIsDragging(false);
+    }
   };
 
   return {
+    isDragging,
     scrollRef,
-    handlePointerDown,
-    handlePointerMove,
-    handlePointerUp,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseLeave,
   };
 }


### PR DESCRIPTION
<!-- title: "[CAN-/커밋 컨벤션의 타입] 제목" -->
<!-- 예시 [CAN-123/feat] admin page 추가 / [CAN-123/refactor] 테스트 후 접근성 개선 -->

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

`해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`
- 대시보드 목표별 할일 UI 개발
- 목표 탭 클릭 시 화면 가운데로 포커스 이동
- 스켈레톤 적용 
- 나중에 Goals에 대한 Tanstack Query만들면 같이 사용할 예정

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 목표 목록 및 목표 탭 컴포넌트가 추가되어, 사용자가 목표와 연결된 할일을 한눈에 확인할 수 있습니다.
  - 새로운 로딩 스켈레톤 컴포넌트가 도입되어, 데이터 로딩 시 시각적으로 진행 상황을 전달합니다.
  - 드래그 스크롤 기능이 추가되어, 목표 목록을 보다 직관적으로 탐색할 수 있습니다.

- **Bug Fixes**
  - 로딩 상태 표시 로직이 간소화되어, 사용자 경험이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->