### PR TITLE
 [CAN-39/feat] 노트 작성하기 API

### DIFF
--- a/src/app/api/goals/[goalId]/route.ts
+++ b/src/app/api/goals/[goalId]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchIntance } from '@/services/fetchInstance';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { goalId: string } },
+) {
+  const { goalId } = params;
+  console.log('GETGETGET goalID', goalId);
+  if (!goalId) {
+    return NextResponse.json(
+      { error: 'goalId를 확인해주세요.' },
+      { status: 400 },
+    );
+  }
+  const res = await fetchIntance({
+    base: 'BACKEND',
+    method: 'GET',
+    url: `/goals/${goalId}`,
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    return NextResponse.json(
+      { error: error.message || '내 목표 조회에 실패했습니다.' },
+      { status: res.status },
+    );
+  }
+  const data = await res.json();
+  return NextResponse.json({ todo: data });
+}

--- a/src/app/api/note/[todoId]/route.ts
+++ b/src/app/api/note/[todoId]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from 'next/server';
+import { fetchIntance } from '@/services/fetchInstance';
+
+// 노트 생성
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { todoId: number } },
+) {
+  const { todoId } = params;
+  const body = await req.json();
+  const { title, content, linkUrl } = body;
+
+  console.log(
+    'todoId, title, content, linkUrl',
+    todoId,
+    title,
+    content,
+    linkUrl,
+  );
+
+  const res1 = await fetchIntance({
+    base: 'CODEIT',
+    method: 'POST',
+    url: '/notes',
+    body: { todoId, title, content, linkUrl },
+  });
+
+  if (!res1.ok) return res1;
+
+  const data = await res1.json();
+  const { noteId } = data;
+
+  const res2 = await fetchIntance({
+    base: 'BACKEND',
+    method: 'PATCH',
+    url: `/todos/${todoId}`,
+    body: { noteId },
+  });
+  return res2;
+}

--- a/src/app/api/note/[todoId]/route.ts
+++ b/src/app/api/note/[todoId]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { fetchIntance } from '@/services/fetchInstance';
 
 // 노트 생성
@@ -6,35 +6,48 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { todoId: number } },
 ) {
-  const { todoId } = params;
-  const body = await req.json();
-  const { title, content, linkUrl } = body;
+  try {
+    const { todoId } = params;
+    const body = await req.json();
+    const { title, content, linkUrl } = body;
 
-  console.log(
-    'todoId, title, content, linkUrl',
-    todoId,
-    title,
-    content,
-    linkUrl,
-  );
+    const res1 = await fetchIntance({
+      base: 'CODEIT',
+      method: 'POST',
+      url: '/notes',
+      body: {
+        todoId: Number(todoId), // 숫자 변환
+        title,
+        content,
+        linkUrl,
+      },
+    });
 
-  const res1 = await fetchIntance({
-    base: 'CODEIT',
-    method: 'POST',
-    url: '/notes',
-    body: { todoId, title, content, linkUrl },
-  });
+    if (!res1.ok) return res1;
 
-  if (!res1.ok) return res1;
+    const data = await res1.json();
 
-  const data = await res1.json();
-  const { noteId } = data;
+    // 노트 id
+    const { id: noteId } = data;
 
-  const res2 = await fetchIntance({
-    base: 'BACKEND',
-    method: 'PATCH',
-    url: `/todos/${todoId}`,
-    body: { noteId },
-  });
-  return res2;
+    // 노트 id를 해당 todo에 업데이트
+    const res2 = await fetchIntance({
+      base: 'BACKEND',
+      method: 'PATCH',
+      url: `/todos/${todoId}`,
+      body: { noteId },
+    });
+
+    const data2 = await res2.json();
+
+    return NextResponse.json(
+      { message: '노트 생성이 완료되었습니다.', data: data2 },
+      { status: 200 },
+    );
+  } catch {
+    return NextResponse.json(
+      { message: '노트 생성 중 에러가 발생했습니다.' },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/todos/[todoId]/route.ts
+++ b/src/app/api/todos/[todoId]/route.ts
@@ -64,3 +64,21 @@ export async function DELETE(
 
   return res2;
 }
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { todoId: number } },
+) {
+  const { todoId } = params;
+
+  const res1 = await fetchIntance({
+    base: 'CODEIT',
+    method: 'GET',
+    url: `/todos/${todoId}`,
+  });
+
+  if (!res1.ok) {
+    return res1;
+  }
+  return res1;
+}

--- a/src/components/note/NoteContentEditor.tsx
+++ b/src/components/note/NoteContentEditor.tsx
@@ -5,6 +5,7 @@ import type ReactQuillType from 'react-quill-new';
 import { Controller } from 'react-hook-form';
 import ErrorMessage from '../auth/ErrorMessage';
 import { NoteFormControlProps } from '@/types/note';
+import NoteSkeleton from './NoteSkeleton';
 
 interface ForwardedQuillProps
   extends React.ComponentProps<typeof ReactQuillType> {
@@ -20,7 +21,7 @@ const QuillNoSSRWrapper = dynamic(
     }
     return Quill;
   },
-  { loading: () => <div>...loading</div>, ssr: false },
+  { loading: () => <NoteSkeleton />, ssr: false },
 );
 
 // 툴바 옵션들

--- a/src/components/note/NoteEditor.tsx
+++ b/src/components/note/NoteEditor.tsx
@@ -5,16 +5,23 @@ import 'react-quill-new/dist/quill.snow.css';
 import { useForm } from 'react-hook-form';
 import { faFontAwesome } from '@fortawesome/free-solid-svg-icons/faFontAwesome';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useParams, useRouter } from 'next/navigation';
 import Button from '../common/button/Button';
 import Icon from '../common/icon/Icon';
 import '@/styles/textEditor.css';
-import { NoteSchema } from '@/lib/note-validation';
+import { NoteSchema, NoteSchemaType } from '@/lib/note-validation';
 import NoteContentEditor from './NoteContentEditor';
 import NoteTitle from './NoteTitle';
+import { createNote } from '@/services/note';
+import { useTodoWithGoalTitle } from '@/hooks/useTodoWithGoalTitle';
+import NoteTitlesSkeleton from './NoteTitlesSkeleton';
 
 export default function NoteEditor() {
+  const { todoId } = useParams<{ todoId: string }>();
+  const router = useRouter();
   const {
     control,
+    handleSubmit,
     formState: { errors, isValid },
     getValues,
     setError,
@@ -27,8 +34,36 @@ export default function NoteEditor() {
     mode: 'onChange',
   });
 
+  // 할 일 제목, 목표 제목 가져오기
+  const { todoQuery, goalQuery } = useTodoWithGoalTitle(todoId);
+
+  const onSubmit = async (formData: NoteSchemaType) => {
+    if (todoId) {
+      try {
+        const res = await createNote({
+          todoId: Number(todoId),
+          formData,
+        });
+
+        // console.log('res________', res);
+
+        if (res) {
+          alert('노트 생성이 완료됐습니다.');
+          router.back();
+        }
+      } catch (error) {
+        console.error('노트 생성 중 오류 발생1:', error);
+      }
+    } else {
+      console.error('todoId가 없습니다.');
+    }
+  };
+
   return (
-    <form className="mx-auto flex h-dvh w-full flex-col overflow-auto break-keep rounded-2xl bg-gs00 p-4 text-gs900 md:px-6 md:py-4">
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="mx-auto flex h-dvh w-full flex-col overflow-auto break-keep rounded-2xl bg-gs00 p-4 text-gs900 md:px-6 md:py-4"
+    >
       <div>
         <div className="mb-4 w-full items-center justify-between xs:flex">
           <h2 className="text-16SB xs:text-18SB">노트 작성</h2>
@@ -51,20 +86,28 @@ export default function NoteEditor() {
           </div>
         </div>
         {/* goal 목표 있을 경우 */}
-        <section className="mb-3 flex items-center gap-2">
-          <Icon
-            icon={faFontAwesome}
-            className="rounded-lg bg-gs800 text-xs text-gs00"
-          />
-          <h3 className="text-16M text-gs800">
-            자바스크립트로 웹 서비스 만들기
-          </h3>
-        </section>
-        {/* todo 상태, todo 제목 */}
-        <article className="mb-2 flex items-center gap-2 text-gs700">
-          <span className="rounded-md bg-gs100 p-1 text-12M">To do</span>
-          <h4 className="text-14R">자바스크립트 기초 챕터1 듣기</h4>
-        </article>
+        {todoQuery.isLoading || goalQuery.isLoading ? (
+          <NoteTitlesSkeleton />
+        ) : (
+          <>
+            {goalQuery.data?.todo.title && (
+              <section className="mb-3 flex items-center gap-2">
+                <Icon
+                  icon={faFontAwesome}
+                  className="rounded-lg bg-gs800 text-xs text-gs00"
+                />
+                <h3 className="text-16M text-gs800">
+                  {goalQuery.data?.todo.title}
+                </h3>
+              </section>
+            )}
+
+            <article className="mb-2 flex items-center gap-2 text-gs700">
+              <span className="rounded-md bg-gs100 p-1 text-12M">To do</span>
+              <h4 className="text-14R">{todoQuery.data?.title}</h4>
+            </article>
+          </>
+        )}
       </div>
       <div className="flex h-full min-h-0 flex-col text-gs800">
         {/* 노트 제목 */}

--- a/src/components/note/NoteSkeleton.tsx
+++ b/src/components/note/NoteSkeleton.tsx
@@ -1,0 +1,11 @@
+export default function NoteSkeleton() {
+  return (
+    <div className="relative size-full">
+      <div className="flex flex-col gap-2">
+        <div className="h-4 animate-pulse bg-gs100" />
+        <div className="h-4 animate-pulse bg-gs100" />
+      </div>
+      <div className="absolute bottom-0 h-11 w-full animate-pulse rounded-full bg-gs100" />
+    </div>
+  );
+}

--- a/src/components/note/NoteTitlesSkeleton.tsx
+++ b/src/components/note/NoteTitlesSkeleton.tsx
@@ -1,0 +1,12 @@
+export default function NoteTitlesSkeleton() {
+  return (
+    <div className="flex flex-col gap-1">
+      <section className="mt-2 flex size-full items-center gap-2">
+        <div className="h-6 w-full animate-pulse bg-gs100" />
+      </section>
+      <article className="mb-2 flex size-full items-center gap-2 text-gs700">
+        <div className="h-6 w-full animate-pulse bg-gs100" />
+      </article>
+    </div>
+  );
+}

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -3,4 +3,6 @@ export const QUERY_KEY = {
   MONTHLY_TODOS: 'MONTHLY_TODOS',
   DAILY_TODOS: 'DAILY_TODOS',
   GRASS: 'GRASS',
+  TODO: 'TODO',
+  GOAL: 'GOAL',
 } as const;

--- a/src/hooks/useTodoWithGoalTitle.ts
+++ b/src/hooks/useTodoWithGoalTitle.ts
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query';
+import { getErrorMessage } from '@/constants/errorMessages';
+import { QUERY_KEY } from '@/constants/queryKey';
+
+const fetchTodoTitle = async ({ queryKey }: { queryKey: [string, string] }) => {
+  const todoId = queryKey[1];
+
+  const res = await fetch(`/api/todos/${todoId}`, { method: 'GET' });
+  if (!res.ok) throw new Error(getErrorMessage(res.status));
+  const data1 = await res.json();
+  return data1;
+};
+
+const fetchGoalTitle = async ({ queryKey }: { queryKey: [string, string] }) => {
+  const goalId = queryKey[1];
+
+  const res = await fetch(`/api/goals/${goalId}`);
+  if (!res.ok) throw new Error(getErrorMessage(res.status));
+  const data33 = await res.json();
+  return data33;
+};
+
+export const useTodoWithGoalTitle = (todoId: string) => {
+  // 첫 번째 쿼리: todoId를 사용하여 할 일 정보 가져오기
+  const {
+    data: todoData,
+    isLoading: isTodoLoading,
+    isError: isTodoError,
+  } = useQuery({
+    queryKey: [QUERY_KEY.TODO, todoId],
+    queryFn: fetchTodoTitle,
+  });
+
+  // 두 번째 쿼리: todoData에서 goalId를 추출하여 목표 제목 가져오기
+  const goalId = todoData?.goal ? todoData.goal.id : undefined;
+
+  const {
+    data: goalData,
+    isLoading: isGoalLoading,
+    isError: isGoalError,
+  } = useQuery({
+    queryKey: [QUERY_KEY.GOAL, goalId],
+    queryFn: fetchGoalTitle,
+    enabled: !!goalId, // goalId가 있을 때만 요청
+  });
+
+  return {
+    todoQuery: {
+      data: todoData,
+      isLoading: isTodoLoading,
+      isError: isTodoError,
+    },
+    goalQuery: {
+      data: goalData,
+      isLoading: isGoalLoading,
+      isError: isGoalError,
+    },
+  };
+};

--- a/src/lib/note-validation.ts
+++ b/src/lib/note-validation.ts
@@ -17,6 +17,7 @@ export const NoteSchema = z.object({
     .min(1, { message: ERROR_MESSAGE.title.empty })
     .max(30, { message: ERROR_MESSAGE.title.max }),
   content: z.string().trim().min(1, { message: ERROR_MESSAGE.content.empty }),
+  linkUrl: z.string().default(''), // 기본값 - 빈 문자열
 });
 
 // 스키마의 z.infer를 사용하여 스키마 유형도 내보내기

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -74,13 +74,13 @@ export const createNote = async ({
         todoId,
         title: formData.title,
         content: formData.content,
-        linkUrl: formData.linkUrl || '',
+        linkUrl: formData.linkUrl || 'https://www.codeit.kr',
       }),
     });
 
     if (!response.ok) throw new Error(getErrorMessage(response.status));
-
-    return { todoId };
+    const data = response.json();
+    return { data };
   } catch (error) {
     console.error('노트 생성 중 오류 발생:', error);
     throw error;

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import { fetchIntance } from './fetchInstance';
+import { getErrorMessage } from '@/constants/errorMessages';
 
 const formatDate = (isoString: string) => {
   const date = new Date(isoString);
@@ -48,5 +49,40 @@ export const getNoteDetail = async (noteId: number) => {
   } catch {
     notFound();
     return null;
+  }
+};
+
+/**
+ * 노트 생성
+ * @param
+ */
+export const createNote = async ({
+  formData,
+  todoId,
+}: {
+  formData: {
+    title: string;
+    content: string;
+    linkUrl: string;
+  };
+  todoId: number;
+}) => {
+  try {
+    const response = await fetch(`/api/note/${todoId}`, {
+      method: 'POST',
+      body: JSON.stringify({
+        todoId,
+        title: formData.title,
+        content: formData.content,
+        linkUrl: formData.linkUrl || '',
+      }),
+    });
+
+    if (!response.ok) throw new Error(getErrorMessage(response.status));
+
+    return { todoId };
+  } catch (error) {
+    console.error('노트 생성 중 오류 발생:', error);
+    throw error;
   }
 };


### PR DESCRIPTION
## 개요 🔎

노트 작성하기 API

## 작업내용 📝

`노트 생성 API 코드잇 연동`
노트 생성 요청을 코드잇 API로 연동하여, 새로운 노트를 생성하는 기능 구현.
성공적으로 노트가 생성된 후, 생성된 노트의 noteId를 반환.

노트 content 저장 시 HTML 형태의 문자열 그대로 데이터베이스에 저장됩니다. 
-> 나중에 스타일과 링크 정보 유지된 그대로 렌더링 가능

`노트 생성 후 백엔드 할일 수정 API 연동`
노트 생성 후, 생성된 noteId를 이용해 해당 노트와 관련된 할일을 백엔드에서 수정하는 API 연동.

`기타 사항`
onSubmit 함수 내에서 
노트 생성 후, router.back()하는 기능 구현.

## 패키지 설치내용 📦



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 리치 텍스트 편집을 지원하는 새로운 의존성이 추가되었습니다.
	- 노트 생성 및 편집 인터페이스와 폼 검증 기능이 도입되어 노트 작성 경험이 향상되었습니다.
	- 투두 및 목표 관련 데이터 처리를 위한 API 기능이 확장되었습니다.
	- 스켈레톤 로딩 UI가 추가되어 콘텐츠 로딩 시 사용자 경험이 개선되었습니다.
	- 목표 및 투두 관련 데이터를 가져오는 새로운 API 경로가 추가되었습니다.
	- 노트 제목 및 내용 입력을 위한 새로운 컴포넌트가 추가되었습니다.

- **Style**
	- 텍스트 에디터 및 비밀번호 입력 관련 컴포넌트의 스타일과 반응형 디자인이 개선되었습니다.

- **Chores**
	- 에러 메시지 및 전반적인 폼 검증 로직이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->