### PR TITLE
[CAN-28/feat] 대시보드 목표 탭 useGoalsTodo 연동

### DIFF
--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -5,10 +5,18 @@ import { useGoals } from '@/hooks/useGoals';
 import GoalTab from './GoalTab';
 import SimpleTodo from '@/components/common/todo/SimpleTodo';
 import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
+import { useGoalTodo } from '@/hooks/useGoalsTodo';
 
 export default function GoalList() {
-  const { data: goals, isFetching: isGoalsFetching } = useGoals();
   const [selectedGoalIndex, setSelectedGoalIndex] = useState<number>(0);
+  const { data: goals, isFetching: isGoalsFetching } = useGoals();
+
+  const selectedGoalId = goals?.[selectedGoalIndex]?.goalId || -1;
+  const {
+    todoItems,
+    doneItems,
+    isLoading: isTodoFetching,
+  } = useGoalTodo(selectedGoalId, !isGoalsFetching && selectedGoalId !== -1);
 
   if (!isGoalsFetching && goals.length === 0)
     return (
@@ -30,25 +38,41 @@ export default function GoalList() {
           <p className="text-14SB">할일</p>
           <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
             {isGoalsFetching && <SimpleTodoSkeleton />}
-            {!isGoalsFetching &&
+            {!isTodoFetching &&
               /** TODO :: 목표 데이터 받아오는 fetch, data로 변경 */
-              Array.from({ length: 5 }, (_, i) => i).map((e) => (
-                <SimpleTodo key={e} title="hihihi" done={false} noteId={3} />
+              todoItems.map((todo) => (
+                <SimpleTodo
+                  key={todo.todoId}
+                  title={todo.title}
+                  done={false}
+                  noteId={todo.noteId}
+                />
               ))}
+            {!isTodoFetching && todoItems.length === 0 && (
+              <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
+                등록된 할일이 없습니다.
+              </span>
+            )}
           </div>
         </section>
         <section className="flex flex-col gap-3 md:flex-[2]">
           <p className="text-14SB">완료</p>
           <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
             {isGoalsFetching && <SimpleTodoSkeleton />}
-            {
-              /** TODO :: 데이터 받아올때 변경 */
-              !isGoalsFetching && (
-                <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
-                  완료된 할일이 없습니다.
-                </span>
-              )
-            }
+            {!isTodoFetching &&
+              doneItems.map((todo) => (
+                <SimpleTodo
+                  key={todo.todoId}
+                  title={todo.title}
+                  done
+                  noteId={todo.noteId}
+                />
+              ))}
+            {!isTodoFetching && doneItems.length === 0 && (
+              <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
+                완료된 할일이 없습니다.
+              </span>
+            )}
           </div>
         </section>
       </div>

--- a/src/hooks/useGoalsTodo.ts
+++ b/src/hooks/useGoalsTodo.ts
@@ -18,7 +18,10 @@ interface GoalTodoResponse {
   error: Error | null;
 }
 
-export const useGoalTodo = (goalId: number): GoalTodoResponse => {
+export const useGoalTodo = (
+  goalId: number,
+  enabled?: boolean,
+): GoalTodoResponse => {
   const {
     data: queryData,
     isLoading,
@@ -39,6 +42,7 @@ export const useGoalTodo = (goalId: number): GoalTodoResponse => {
         basketTodos: Array.isArray(data.basketTodos) ? data.basketTodos : [],
       };
     },
+    enabled: enabled || true,
   });
 
   const todoItems = queryData?.todos.filter((item) => !item.done) || [];

--- a/src/hooks/useGoalsTodo.ts
+++ b/src/hooks/useGoalsTodo.ts
@@ -42,7 +42,7 @@ export const useGoalTodo = (
         basketTodos: Array.isArray(data.basketTodos) ? data.basketTodos : [],
       };
     },
-    enabled: enabled || true,
+    enabled: enabled === undefined ? true : enabled,
   });
 
   const todoItems = queryData?.todos.filter((item) => !item.done) || [];


### PR DESCRIPTION
<!-- title: "[CAN-/커밋 컨벤션의 타입] 제목" -->
<!-- 예시 [CAN-123/feat] admin page 추가 / [CAN-123/refactor] 테스트 후 접근성 개선 -->

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

`해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`
- 대시보드 목표 탭 useGoalsTodo 연동

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 선택한 목표에 따른 투두 및 완료 항목이 대시보드에서 더 명확하게 표시됩니다.
	- 투두 항목이 없는 경우, 사용자에게 명확한 안내 메시지가 제공됩니다.
- **리팩터**
	- 투두 항목과 완료 항목의 로딩 상태 처리가 개선되어 대시보드의 사용자 경험이 향상되었습니다.
	- `useGoalTodo` 훅이 추가적인 조건부 매개변수를 지원하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->