### PR TITLE
[CAN-50/feat] 할 일 장바구니 디자인 추가

### DIFF
--- a/src/app/(member)/layout.tsx
+++ b/src/app/(member)/layout.tsx
@@ -1,4 +1,5 @@
 import Navbar from '@/components/common/navbar/Navbar';
+import { NavbarProvider } from '@/components/common/NavbarContext';
 
 export default function Layout({
   children,
@@ -8,14 +9,16 @@ export default function Layout({
   modal: React.ReactNode;
 }>) {
   return (
-    <div className="flex h-screen w-screen overflow-hidden bg-gs100 will-change-scroll">
-      <Navbar />
-      <div className="ml-16 flex-1 overflow-y-auto overscroll-contain md:ml-0">
-        <div className="relative left-1/2 flex max-h-[1000px] w-full max-w-screen-xl -translate-x-1/2 flex-col gap-4 overflow-auto p-4 md:h-screen md:gap-8 md:p-10">
-          {children}
+    <NavbarProvider>
+      <div className="flex h-screen w-screen overflow-hidden bg-gs100 will-change-scroll">
+        <Navbar />
+        <div className="ml-16 flex-1 overflow-y-auto overscroll-contain md:ml-0">
+          <div className="relative left-1/2 flex max-h-[1000px] w-full max-w-screen-xl -translate-x-1/2 flex-col gap-4 overflow-auto p-4 md:h-screen md:gap-8 md:p-10">
+            {children}
+          </div>
+          {modal}
         </div>
-        {modal}
       </div>
-    </div>
+    </NavbarProvider>
   );
 }

--- a/src/components/common/NavbarContext.tsx
+++ b/src/components/common/NavbarContext.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, useMemo } from 'react';
+
+interface Props {
+  isFolded: boolean;
+  toggleNavbar: () => void;
+}
+
+const NavbarContext = createContext<Props | undefined>(undefined);
+export function NavbarProvider({ children }: { children: React.ReactNode }) {
+  const [isFolded, setIsFolded] = useState(false);
+
+  useEffect(() => {
+    setIsFolded(window.innerWidth <= 768);
+  }, []);
+
+  const toggleNavbar = () => {
+    setIsFolded((prev) => !prev);
+  };
+
+  const contextValue = useMemo(() => ({ isFolded, toggleNavbar }), [isFolded]);
+
+  return (
+    <NavbarContext.Provider value={contextValue}>
+      {children}
+    </NavbarContext.Provider>
+  );
+}
+
+export function useNavbar() {
+  const context = useContext(NavbarContext);
+  if (!context) {
+    throw new Error('useNavbar must be used within a NavbarProvider');
+  }
+  return context;
+}

--- a/src/components/common/navbar/Navbar.tsx
+++ b/src/components/common/navbar/Navbar.tsx
@@ -2,18 +2,14 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons/faAngleRight';
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import cn from '@/utils/cn';
 import NavUserProfile from './NavUserProfile';
 import NavTab from './NavTab';
+import { useNavbar } from '../NavbarContext';
 
 export default function Navbar() {
-  const [isFolded, setIsFolded] = useState<boolean>(false);
-
-  useEffect(() => {
-    setIsFolded(window.innerWidth <= 768);
-  }, []);
+  const { isFolded, toggleNavbar } = useNavbar();
 
   return (
     <>
@@ -31,7 +27,7 @@ export default function Navbar() {
             'absolute right-0 top-20 z-10 flex h-10 w-5 items-center justify-center rounded-l-md bg-slate50',
           )}
           type="button"
-          onClick={() => setIsFolded((prev) => !prev)}
+          onClick={toggleNavbar}
         >
           <FontAwesomeIcon
             className={cn('h-3 w-3 transition-transform duration-300', {
@@ -57,7 +53,7 @@ export default function Navbar() {
         className={cn('md:hidden', {
           'fixed inset-0 z-10 bg-black bg-opacity-50': !isFolded,
         })}
-        onClick={() => setIsFolded(true)}
+        onClick={toggleNavbar}
       />
     </>
   );

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -236,7 +236,7 @@ export default function CalendarBody({
       dayHeaderFormat={{ weekday: 'long' }}
       dayHeaderClassNames="border-[0.5px] border-gs200 bg-gs50 !py-2 text-12M text-gs500 xl:text-14M"
       height="auto"
-      contentHeight="100%"
+      contentHeight="auto"
       dayCellContent={(info) => renderDayCellContent(info)}
       dayCellClassNames={(info) => getDayCellClassNames(info)}
       dayCellDidMount={handleDayCellMount}

--- a/src/components/todoCalendar/TodoBasket.tsx
+++ b/src/components/todoCalendar/TodoBasket.tsx
@@ -1,19 +1,29 @@
 import { Draggable } from '@fullcalendar/interaction';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { Goal } from '@/types/goals';
+import IconButton from '../common/button/IconButton';
+import Button from '../common/button/Button';
+import Icon from '../common/icon/Icon';
+import cn from '@/utils/cn';
+import { useNavbar } from '../common/NavbarContext';
 
 interface Props {
   basketList: { id: number; title: string; goal: Goal | null }[];
-  onDeleteBasketTodo: (id: number) => void;
-  onDeleteAllBasket: () => void;
 }
 
-export default function TodoBasket({
-  basketList,
-  onDeleteBasketTodo,
-  onDeleteAllBasket,
-}: Props) {
+export default function TodoBasket({ basketList }: Props) {
   const basketRef = useRef<HTMLDivElement>(null);
+  const [isAdding, setIsAdding] = useState(false);
+  const [nowBasketList, setNowBasketList] = useState(basketList);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { isFolded } = useNavbar();
+  useEffect(() => {
+    if (isAdding && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isAdding]);
 
   useEffect(() => {
     if (basketRef.current) {
@@ -28,46 +38,99 @@ export default function TodoBasket({
     }
     return undefined;
   }, []);
-  return (
-    <div className="w-full bg-white p-3">
-      <div className="mb-3 flex items-center gap-4">
-        <span className="text-lg font-semibold">할 일 장바구니</span>
-        <button
-          type="button"
-          className="rounded-lg border border-blue-500 px-3 py-1 text-blue-500 hover:bg-blue-100"
-        >
-          생성
-        </button>
-        <button
-          type="button"
-          className="rounded-lg border border-blue-500 px-3 py-1 text-blue-500 hover:bg-blue-100"
-          onClick={() => onDeleteAllBasket()}
-        >
-          모두 삭제
-        </button>
-      </div>
-      <div
-        ref={basketRef}
-        className="flex max-h-40 flex-wrap gap-3 overflow-y-auto"
-      >
-        {basketList.map((todo) => (
-          <div
-            key={todo.id}
-            className="draggable-todo flex w-[150px] cursor-grab items-center justify-between gap-3 rounded-lg border p-3 shadow-sm active:cursor-grabbing"
-            draggable
-            data-id={todo.id}
+
+  const handleAddTodo = () => {
+    const title = inputRef.current?.value.trim();
+    if (!title) return;
+
+    setNowBasketList((prev) => [
+      ...prev,
+      { id: Date.now(), title, goal: null },
+    ]);
+    setIsAdding(false);
+  };
+
+  const handleKeyDown = async (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === 'Escape') setIsAdding(false);
+    else if (event.key === 'Enter') {
+      handleAddTodo();
+    }
+  };
+
+  const handleDeleteTodo = (id: number) => {
+    setNowBasketList((prev) => prev.filter((todo) => todo.id !== id));
+  };
+
+  const handleDeleteAllTodos = () => {
+    setNowBasketList([]);
+  };
+
+  return createPortal(
+    <div
+      className={cn(
+        'fixed bottom-0 z-10 bg-white px-6 pb-2 pt-4 transition-all duration-300 ease-in-out',
+        {
+          'left-16 w-[calc(100vw-4rem)]': isFolded,
+          'left-16 w-[calc(100vw-4rem)] md:left-64 md:w-[calc(100vw-16rem)] 2xl:left-80 2xl:w-[calc(100vw-20rem)]':
+            !isFolded,
+        },
+      )}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex justify-between px-4">
+          <h1 className="text-18SB text-gsBk">할일 장바구니</h1>
+          <button
+            type="button"
+            className="text-14M text-gs600"
+            onClick={() => handleDeleteAllTodos()}
           >
-            <span className="truncate">{todo.title}</span>
-            <button
-              type="button"
-              className="text-gray-500"
-              onClick={() => onDeleteBasketTodo(todo.id)}
+            모두 지우기
+          </button>
+        </div>
+        <div
+          ref={basketRef}
+          className="mb-4 flex h-36 flex-wrap gap-3 overflow-y-auto pl-4"
+        >
+          {isAdding ? (
+            <div className="flex h-14 max-w-80 items-center justify-center gap-2 rounded-lg bg-slate50 p-3 focus-within:border focus-within:border-slate500 hover:bg-slate100">
+              <input
+                ref={inputRef}
+                type="text"
+                onKeyDown={handleKeyDown}
+                onBlur={() => setIsAdding(false)}
+                className="bg-transparent text-16R text-gsBk focus:outline-none"
+              />
+              <IconButton icon={faXmark} className="text-gs400" />
+            </div>
+          ) : (
+            <Button
+              className="active:none acitve:border-inherit acitve:border-2 active:border-slage300 h-14 border-2 border-slate300 bg-gs20 p-3 text-14R text-slate700 transition-all hover:border-transparent hover:bg-slate100 focus:border focus:border-slate500 focus:bg-slate50 focus:text-gsBk active:bg-gs20 2xl:text-16R"
+              onClick={() => setIsAdding(true)}
             >
-              x
-            </button>
-          </div>
-        ))}
+              <Icon icon={faPlus} />
+              장바구니에 새 할일 추가
+            </Button>
+          )}
+          {nowBasketList.map((todo) => (
+            <div
+              key={todo.id}
+              className="draggable-todo flex h-14 max-w-80 cursor-grab items-center justify-between gap-2 rounded-lg bg-slate50 p-3 active:cursor-grabbing active:bg-slate200"
+              draggable
+              data-id={todo.id}
+            >
+              <span className="truncate text-16R text-gsBk">{todo.title}</span>
+              <IconButton
+                icon={faXmark}
+                className="text-gs400"
+                onClick={() => handleDeleteTodo(todo.id)}
+              />
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/components/todoCalendar/TodoBasket.tsx
+++ b/src/components/todoCalendar/TodoBasket.tsx
@@ -91,7 +91,7 @@ export default function TodoBasket({ basketList }: Props) {
         </div>
         <div
           ref={basketRef}
-          className="mb-4 flex h-36 flex-wrap gap-3 overflow-y-auto pl-4"
+          className="mb-4 flex h-20 flex-wrap gap-3 overflow-y-auto pl-4 md:h-36"
         >
           {isAdding ? (
             <div className="flex h-14 max-w-80 items-center justify-center gap-2 rounded-lg bg-slate50 p-3 focus-within:border focus-within:border-slate500 hover:bg-slate100">

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -118,7 +118,7 @@ export default function TodoCalendar() {
     </div>
   ) : (
     <div className="relative w-full">
-      <div className="flex flex-col justify-center gap-4 md:flex-row">
+      <div className="flex max-h-[calc(100vh-270px)] flex-col justify-center gap-4 overflow-auto px-1 md:flex-row">
         <div className="flex-1">
           {isLoading ? (
             <Loading />

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -4,10 +4,10 @@ import React, { useEffect, useRef, useState } from 'react';
 import Calendar from './Calendar';
 
 import TodoList from './TodoList';
-import { Basket } from '@/types/todos';
 import TodoModal from './TodoModal';
 import Loading from '../common/Loading';
 import { useDailyTodos, useMonthlyTodos } from '@/hooks/useTodos';
+import TodoBasket from './TodoBasket';
 
 // import Loading from '../common/Loading';
 // import TodoBasket from './TodoBasket';
@@ -48,7 +48,6 @@ export default function TodoCalendar() {
   const [currentMonth, setCurrentMonth] = useState<number>(
     new Date().getMonth() + 1,
   );
-  const [basketList, setBasketList] = useState<Basket[]>(initialBasketList);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [calendarHeight, setCalendarHeight] = useState<number>(0);
   const [isCalendarLoaded, setIsCalendarLoaded] = useState(false);
@@ -79,26 +78,12 @@ export default function TodoCalendar() {
   };
 
   /**
-   * 장바구니에서 할 일 삭제
-   * @param id 삭제할 할 일의 id
-   */
-  // const handleDeleteBasketTodo = (id: number) => {
-  //   setBasketList((prev) => prev.filter((todo) => todo.id !== id));
-  // };
-
-  /**
-   * 모든 장바구니 삭제
-   */
-  // const handleDeleteAllBasket = () => {
-  //   setBasketList([]);
-  // };
-
-  /**
    * 드랍 시 todo에 추가 & 장바구니에서 제거
    */
   const handleDropTodo = (date: string, todoId: number) => {
-    const draggedTodo = basketList.find((todo) => todo.id === todoId);
-    if (!draggedTodo) return;
+    console.log(date, todoId);
+    // const draggedTodo = basketList.find((todo) => todo.id === todoId);
+    // if (!draggedTodo) return;
     // const newTodo: Todo = {
     //   id: todoId,
     //   title: draggedTodo.title,
@@ -107,7 +92,7 @@ export default function TodoCalendar() {
     //   done: false,
     // };
     // setTodos((prev) => [...prev, newTodo]);
-    setBasketList((prev) => prev.filter((todo) => todo.id !== todoId));
+    // setBasketList((prev) => prev.filter((todo) => todo.id !== todoId));
   };
 
   useEffect(() => {
@@ -132,47 +117,42 @@ export default function TodoCalendar() {
       <p className="text-red-500">데이터를 불러오는 중 오류 발생</p>
     </div>
   ) : (
-    <div className="flex flex-col justify-center gap-4 md:flex-row">
-      <div className="flex-1">
-        {isLoading ? (
-          <Loading />
-        ) : (
-          <Calendar
-            todos={monthlyTodos}
-            selectedDate={selectedDate}
-            onDateChange={setSelectedDate}
-            onDropTodo={handleDropTodo}
-            calendarDivRef={calendarRef}
-            isCalendarLoaded={isCalendarLoaded}
-            onMonthChange={(year, month) => {
-              setCurrentYear(year);
-              setCurrentMonth(month);
-            }}
-          />
-        )}
-        {!isCalendarLoaded && <Loading />}
-      </div>
-      {isCalendarLoaded && (
-        <div
-          className="size-full md:w-[280px] xl:w-[350px]"
-          style={{ height: calendarHeight }}
-        >
-          <TodoList
-            selectedDate={selectedDate}
-            todos={dailyTodos}
-            onOpenModal={handleOpenModal}
-          />
+    <div className="relative w-full">
+      <div className="flex flex-col justify-center gap-4 md:flex-row">
+        <div className="flex-1">
+          {isLoading ? (
+            <Loading />
+          ) : (
+            <Calendar
+              todos={monthlyTodos}
+              selectedDate={selectedDate}
+              onDateChange={setSelectedDate}
+              onDropTodo={handleDropTodo}
+              calendarDivRef={calendarRef}
+              isCalendarLoaded={isCalendarLoaded}
+              onMonthChange={(year, month) => {
+                setCurrentYear(year);
+                setCurrentMonth(month);
+              }}
+            />
+          )}
+          {!isCalendarLoaded && <Loading />}
         </div>
-      )}
-      {/* {isCalendarReady && (
-          <TodoBasket
-            basketList={basketList}
-            onDeleteBasketTodo={handleDeleteBasketTodo}
-            onDeleteAllBasket={handleDeleteAllBasket}
-          />
+        {isCalendarLoaded && (
+          <div
+            className="size-full md:w-[280px] xl:w-[350px]"
+            style={{ height: calendarHeight }}
+          >
+            <TodoList
+              selectedDate={selectedDate}
+              todos={dailyTodos}
+              onOpenModal={handleOpenModal}
+            />
+          </div>
         )}
+      </div>
+      {isCalendarLoaded && <TodoBasket basketList={initialBasketList} />}
 
-        )} */}
       {isModalOpen && (
         <TodoModal
           selectedDate={selectedDate}

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -117,8 +117,8 @@ export default function TodoCalendar() {
       <p className="text-red-500">데이터를 불러오는 중 오류 발생</p>
     </div>
   ) : (
-    <div className="relative w-full">
-      <div className="flex max-h-[calc(100vh-270px)] flex-col justify-center gap-4 overflow-auto px-1 md:flex-row">
+    <div className="relative h-screen max-h-[calc(100vh-160px)] w-full overflow-auto md:max-h-[calc(100vh-270px)]">
+      <div className="flex flex-col justify-center gap-4 px-1 md:flex-row">
         <div className="flex-1">
           {isLoading ? (
             <Loading />
@@ -140,7 +140,7 @@ export default function TodoCalendar() {
         </div>
         {isCalendarLoaded && (
           <div
-            className="size-full md:w-[280px] xl:w-[350px]"
+            className="w-full md:w-[280px] xl:w-[350px]"
             style={{ height: calendarHeight }}
           >
             <TodoList


### PR DESCRIPTION
## 개요 🔎

## 작업내용 📝
현재 디자인만 적용하고 기능은 구현되지 않았습니당
참고해주세요

> 장바구니는 하단에 fix 되어야함
- layout에 있는 screen-xl가 적용되면 안되기 때문에 `createPortal` 사용하여 body 밑에 띄움
- navbar가 접힘에 따라 장바구니 위치와 width도 변경되어야 하기 때문에 navbar 접힘 상태를 context로 관리
- 장바구니로 인해 캘린더 부분이 잘려서, 우선 내부스크롤로 구현. -> 이 부분 이상하다고 생각되면 변경하겠습니다

> 장바구니 UI
- FullCalendar 라이브러리는 드래그 드랍 요소를 커스텀할 수 있는 기능을 제공하지 않음
- 그래서 피그마에 있는 디자인 적용이 어려울 것으로 보아 우선 지금 되어있는 대로 사용 예정
- 추후 시간이 남는다면 마지막에 구현 할 예정

## 패키지 설치내용 📦

<img width="1597" alt="image" src="https://github.com/user-attachments/assets/da42e263-1f3f-4b10-87b6-e7cb57dcc5da" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 내비게이션 메뉴가 반응형으로 개선되어, 다양한 화면에서 보다 원활한 토글 경험을 제공합니다.
  - 할 일 목록 관리 기능이 강화되어, 할 일 항목을 쉽게 추가 및 삭제하고 전체 목록을 초기화할 수 있습니다.
- **UI 개선**
  - 달력 레이아웃이 콘텐츠 양에 맞춰 자동으로 높이를 조절하여, 보다 유연하고 깔끔한 화면 구성이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->