### PR TITLE
[CAN-62/feat] 노트 리스트 API 연동

### DIFF
--- a/src/app/(member)/goals/[id]/note/page.tsx
+++ b/src/app/(member)/goals/[id]/note/page.tsx
@@ -1,58 +1,24 @@
-import { config } from '@fortawesome/fontawesome-svg-core';
-import '@fortawesome/fontawesome-svg-core/styles.css';
-import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Link from 'next/link';
+'use client';
+
+import { useNoteList } from '@/hooks/useNotes';
 import NoteHeader from '@/components/note/NoteHeader';
 import NoteList from '@/components/note/NoteList';
 
-config.autoAddCss = false;
-
-const notes = [
-  {
-    id: 494,
-    title: '자바스크립트를 배우기 전 알아두어야 할 것',
-    todo: '자바스크립트 기초 1',
-    content: '내용이 어쩌구 저쩌구 내용이 어쩌구 저쩌구',
-    date: '2024.02.04',
-  },
-  {
-    id: 2,
-    title: '자바스크립트를 시작하기 전 준비물',
-    todo: '자바스크립트 기초 2',
-    content: '내용이 어쩌구 저쩌구 내용이 어쩌구 저쩌구',
-    date: '2024.02.04',
-  },
-  {
-    id: 3,
-    title: '프로그래밍 시작하기 in JavaScript',
-    todo: '자바스크립트 기초 3',
-    content: '내용이 어쩌구 저쩌구 내용이 어쩌구 저쩌구',
-    date: '2024.02.04',
-  },
-  {
-    id: 4,
-    title: '프로그래밍과 데이터 in JavaScript',
-    todo: '자바스크립트 기초 4',
-    content: '내용이 어쩌구 저쩌구 내용이 어쩌구 저쩌구',
-    date: '2024.02.04',
-  },
-];
-
 export default function Page({ params }: { params: { id: string } }) {
+  const goalId = Number(params.id);
+  const { data: notes, isLoading, error } = useNoteList(goalId);
+
+  if (isLoading) return <p className="text-center">Loading...</p>;
+  if (error)
+    return <p className="text-center text-red-500">Failed to load notes</p>;
+
   return (
     <div className="relative left-1/2 w-full max-w-screen-xl -translate-x-1/2 bg-gs100">
-      <div className="mb-4 flex items-center gap-2 text-18SB">
-        <Link href={`/goals/${params.id}`}>
-          <FontAwesomeIcon icon={faArrowLeft} />
-        </Link>
-        노트 모아보기
-      </div>
-      <div className="mb-3 h-[52px] rounded-xl bg-gs00 p-3 shadow">
+      <div className="mb-8 flex h-[68px] items-center rounded-xl bg-gs00 shadow">
         <NoteHeader id={params.id} />
       </div>
       <div>
-        <NoteList notes={notes} />
+        <NoteList notes={notes ?? []} />
       </div>
     </div>
   );

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { fetchIntance } from '@/services/fetchInstance';
+
+// 목표별 노트 리스트
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const goalId = searchParams.get('goalId');
+
+  if (!goalId || Number.isNaN(Number(goalId))) {
+    return NextResponse.json({ error: 'Invalid goalId' }, { status: 400 });
+  }
+
+  const res = await fetchIntance({
+    base: 'CODEIT',
+    method: 'GET',
+    url: `/notes?goalId=${goalId}`,
+  });
+
+  return res;
+}

--- a/src/components/goalDetail/GoalTodoList.tsx
+++ b/src/components/goalDetail/GoalTodoList.tsx
@@ -3,6 +3,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import cn from '@/utils/cn';
 import CheckTodo from '@/components/common/todo/CheckTodo';
 import GoalTodoModal from './GoalTodoModal';
@@ -23,7 +24,7 @@ interface GroupedTodos {
 export default function GoalTodoList({ list, onToggle, goalId }: Props) {
   const groupedTodos: GroupedTodos = { past: {}, today: [], upcoming: {} };
   const today = new Date().toLocaleDateString('sv-SE');
-
+  const router = useRouter();
   const [isFutureFold, setIsFutureFold] = useState(true);
   const [isPastFold, setIsPastFold] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -64,6 +65,14 @@ export default function GoalTodoList({ list, onToggle, goalId }: Props) {
     }
   });
 
+  const handleClickNote = (todo: Todo) => {
+    if (todo.noteId) {
+      router.push(`/note/${todo.noteId}`);
+    } else {
+      router.push(`/${todo.todoId}/note/create`);
+    }
+  };
+
   const isEmpty =
     groupedTodos.today.length === 0 &&
     Object.keys(groupedTodos.upcoming).length === 0 &&
@@ -101,6 +110,7 @@ export default function GoalTodoList({ list, onToggle, goalId }: Props) {
                     noteId={todo.noteId ?? null}
                     onCheck={() => onToggle(todo.todoId)}
                     goal={todo.goal}
+                    onClickNote={() => handleClickNote(todo)}
                   />
                 ))}
               </div>
@@ -139,6 +149,7 @@ export default function GoalTodoList({ list, onToggle, goalId }: Props) {
                             noteId={todo.noteId ?? null}
                             onCheck={() => onToggle(todo.todoId)}
                             goal={todo.goal}
+                            onClickNote={() => handleClickNote(todo)}
                           />
                         ))}
                       </div>
@@ -180,6 +191,7 @@ export default function GoalTodoList({ list, onToggle, goalId }: Props) {
                             noteId={todo.noteId ?? null}
                             onCheck={() => onToggle(todo.todoId)}
                             goal={todo.goal}
+                            onClickNote={() => handleClickNote(todo)}
                           />
                         ))}
                       </div>

--- a/src/components/note/NoteHeader.tsx
+++ b/src/components/note/NoteHeader.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFlag } from '@fortawesome/free-solid-svg-icons';
-import { useGoals } from '@/hooks/useGoals';
+import Link from 'next/link';
 import { Goal } from '@/types/goals';
+import { useGoals } from '@/hooks/useGoals';
 
 interface Props {
   id: string;
@@ -17,8 +18,10 @@ export default function NoteHeader({ id }: Props) {
   )?.title;
 
   return (
-    <h1 className="flex items-center gap-2 px-3 text-16R font-semibold">
-      <FontAwesomeIcon icon={faFlag} className="text-slate500" />
+    <h1 className="flex items-center gap-2 px-6 text-20M">
+      <Link href={`/goals/${id}`}>
+        <FontAwesomeIcon icon={faArrowLeft} />
+      </Link>
       {isLoading ? '목표 로딩 중...' : goalTitle}
     </h1>
   );

--- a/src/components/note/NoteItem.tsx
+++ b/src/components/note/NoteItem.tsx
@@ -1,21 +1,11 @@
 'use client';
 
-import {
-  faLayerGroup,
-  faEllipsisVertical,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { useState } from 'react';
 import Link from 'next/link';
-import ConfirmDeleteModal from '@/components/note/ConfirmDeleteModal';
-import { useClickOutside } from '@/hooks/useClickOutside';
 
 interface Note {
   id: number;
   title: string;
-  todo: string;
-  content: string;
-  date: string;
+  todo: { title: string };
 }
 
 interface NoteItemProps {
@@ -23,82 +13,21 @@ interface NoteItemProps {
 }
 
 export default function NoteItem({ note }: NoteItemProps) {
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [menuRef, isMenuOpen, setIsMenuOpen] = useClickOutside<HTMLDivElement>(
-    () => setIsMenuOpen(false),
-  );
-
-  const handleDelete = () => {
-    setIsDeleteModalOpen(false);
-  };
-
   return (
-    <>
-      <div className="mb-4 rounded-xl border bg-gs00 shadow-md sm:max-h-[192px] md:max-h-[160px] lg:max-h-[164px]">
-        <div className="p-6">
-          {/* 상단 아이콘 */}
-          <div className="flex items-center justify-between">
-            <div className="flex size-7 items-center justify-center rounded-full bg-slate100 text-slate300">
-              <FontAwesomeIcon icon={faLayerGroup} />
-            </div>
+    <div className="mb-4 rounded-xl border bg-gs00 p-6 shadow-md sm:max-h-[200px] md:max-h-[200px] lg:max-h-[120px]">
+      {/* 제목 */}
+      <Link
+        href={`/note/${note.id}`}
+        className="block w-full cursor-pointer border-b pb-3 text-left text-18M font-semibold hover:text-slate500"
+      >
+        {note.title}
+      </Link>
 
-            <div className="relative" ref={menuRef}>
-              <div
-                className="flex size-8 cursor-pointer items-center justify-center rounded-full bg-gs100"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setIsMenuOpen((prev) => !prev);
-                }}
-              >
-                <FontAwesomeIcon
-                  icon={faEllipsisVertical}
-                  className="text-gs400"
-                />
-              </div>
-              {isMenuOpen && (
-                <div className="absolute right-0 z-10 mt-2 w-24 rounded bg-gs00 shadow-md">
-                  <button
-                    type="button"
-                    className="block w-full border-b px-4 py-2 text-14R text-gs700 hover:bg-gs200"
-                  >
-                    수정하기
-                  </button>
-                  <button
-                    type="button"
-                    className="block w-full px-4 py-2 text-14R text-gs700 hover:bg-gs200"
-                    onClick={() => {
-                      setIsDeleteModalOpen(true);
-                      setIsMenuOpen(false);
-                    }}
-                  >
-                    삭제하기
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* 제목 */}
-          <Link
-            href={`/note/${note.id}`}
-            className="mt-2 block w-full cursor-pointer border-b pb-3 text-left text-18M font-semibold hover:text-slate500"
-          >
-            {note.title}
-          </Link>
-
-          {/* todo */}
-          <div className="mb-6 mt-3 flex items-center gap-2 text-12M text-gs700">
-            <span className="mr-2 rounded-lg bg-gs200 p-2">To do</span>
-            <span>{note.todo}</span>
-          </div>
-        </div>
+      {/* todo */}
+      <div className="mt-3 flex items-center gap-2 text-gs700">
+        <span className="mr-2 rounded-[4px] bg-gs200 p-1 text-12SB">To do</span>
+        <span className="mr-2 text-12R">{note.todo.title}</span>
       </div>
-      {/* 모달 */}
-      <ConfirmDeleteModal
-        isOpen={isDeleteModalOpen}
-        onClose={() => setIsDeleteModalOpen(false)}
-        onDelete={handleDelete}
-      />
-    </>
+    </div>
   );
 }

--- a/src/components/note/NoteList.tsx
+++ b/src/components/note/NoteList.tsx
@@ -4,9 +4,7 @@ import NoteItem from '@/components/note/NoteItem';
 interface Note {
   id: number;
   title: string;
-  todo: string;
-  content: string;
-  date: string;
+  todo: { title: string };
 }
 
 interface NoteListProps {
@@ -17,9 +15,7 @@ export default function NoteList({ notes }: NoteListProps) {
   return (
     <div>
       {notes.length === 0 && (
-        <div className="-translate-x-1/2l relative left-1/2 w-full max-w-screen-xl py-8 text-center text-gs500">
-          아직 등록된 노트가 없어요.
-        </div>
+        <div className="text-center text-gs500">아직 등록된 노트가 없어요.</div>
       )}
       {notes.map((note) => (
         <NoteItem key={note.id} note={note} />

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@/constants/queryKey';
-import { getNoteDetail } from '@/services/note';
+import { getNoteDetail, getNotes } from '@/services/note';
 import { NoteDetail } from '@/types/note';
 
 export const useNoteDetail = (noteId: number, initialData: NoteDetail) => {
@@ -10,3 +10,10 @@ export const useNoteDetail = (noteId: number, initialData: NoteDetail) => {
     initialData,
   });
 };
+
+export function useNoteList(goalId: number) {
+  return useQuery({
+    queryKey: [QUERY_KEY.NOTE, goalId],
+    queryFn: () => getNotes(goalId),
+  });
+}

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -98,3 +98,15 @@ export const createNote = async ({
     throw error;
   }
 };
+
+// 목표별 노트 리스트 가져오기
+export async function getNotes(goalId: number) {
+  const res = await fetch(`/api/notes?goalId=${goalId}`);
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch notes');
+  }
+
+  const data = await res.json();
+  return data.notes;
+}


### PR DESCRIPTION

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

-목표에 해당하는 노트 리스트 조회 & 변경된 UI 적용

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 목표와 연동된 노트를 비동기 방식으로 불러와, 로딩 및 오류 상태를 사용자에게 안내합니다.
	- 할일 항목 클릭 시 관련 노트로 이동하거나 새 노트 생성 페이지로 안내하는 기능이 추가되었습니다.
	- 목표 기반 노트 조회를 위한 새로운 API 기능이 도입되었습니다.

- **Refactor & Style**
	- 노트 관련 UI 컴포넌트가 단순화되어 보다 깔끔한 사용자 경험을 제공합니다.
	- 헤더 디자인 및 내비게이션 요소가 개선되어 접근성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->