### PR TITLE
[CAN-14/feat] 캘린더 페이지 반응형 구현

### DIFF
--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -28,7 +28,7 @@ export default function ConfirmModal({
 }: Props) {
   return createPortal(
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50">
-      <div className="flex w-[450px] flex-col gap-6 rounded-lg bg-gs00 p-6">
+      <div className="flex w-[300px] flex-col gap-6 rounded-lg bg-gs00 p-6 md:w-[450px]">
         <div className="flex w-full flex-col items-center justify-center gap-1">
           <div className="px-4 py-2">
             <div className="flex size-16 items-center justify-center rounded-full bg-gray-400">

--- a/src/components/note/noteDetail/NoteModal.tsx
+++ b/src/components/note/noteDetail/NoteModal.tsx
@@ -37,7 +37,7 @@ export default function NoteModal({ noteId }: Props) {
           />
           <motion.div
             ref={modalRef}
-            className="fixed inset-y-0 right-0 z-40 flex max-h-full flex-col bg-gs00 pb-6 shadow-lg sm:w-full lg:w-[45%] xl:w-[45%]"
+            className="fixed inset-y-0 right-0 z-40 flex max-h-full w-full flex-col bg-gs00 pb-6 shadow-lg lg:w-[45%]"
             initial={{ x: '100%' }}
             animate={{ x: 0 }}
             exit={{ x: '100%' }}

--- a/src/components/todoCalendar/CreateTodo.tsx
+++ b/src/components/todoCalendar/CreateTodo.tsx
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import TextInput from '@/components/common/input/TextInput';
 import DropDownInput from '@/components/common/input/DropDownInput';
 import DateInput from '../common/input/DateInput';
@@ -8,6 +9,7 @@ import cn from '@/utils/cn';
 import Button from '../common/button/Button';
 import { useGoals } from '@/hooks/useGoals';
 import { useAddTodo, useUpdateTodo } from '@/hooks/useTodos';
+import IconButton from '../common/button/IconButton';
 
 const createTodoSchema = z.object({
   title: z
@@ -82,53 +84,58 @@ export default function CreateTodo({
   const watchedValues = watch();
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50">
-      <div className="flex w-[520px] flex-col gap-6 rounded-lg bg-gs00 p-6">
+    <div className="flex h-full w-[520px] flex-col gap-6 bg-gs00 p-6 md:h-auto md:rounded-lg">
+      <div className="flex justify-between">
         <h2 className="text-18SB">{isEdit ? '할일 수정' : '할일 생성'}</h2>
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-10">
-            <div className="flex flex-col gap-6">
-              <TextInput<TodoFormValues>
-                name="title"
-                label="할일 제목"
-                placeholder="할일의 제목을 작성하세요"
-                control={control}
-                errors={errors}
-              />
-              <DateInput<TodoFormValues>
-                name="date"
-                label="날짜"
-                control={control}
-              />
-              <DropDownInput<TodoFormValues>
-                name="goal"
-                label="목표"
-                placeholder="목표를 선택해주세요"
-                options={goalList}
-                control={control}
-                isLoading={isLoading}
-              />
-            </div>
-            <div className="flex w-full flex-row gap-2">
-              <Button
-                size="full"
-                onClick={() => onShowConfirmModal(watchedValues)}
-                className="bg-gs100 py-4 text-gs600 hover:bg-gs100 focus:bg-gs100 active:bg-gs100"
-              >
-                취소
-              </Button>
-              <Button
-                size="full"
-                type="submit"
-                disabled={!isValid}
-                className={cn('py-4')}
-              >
-                확인
-              </Button>
-            </div>
-          </div>
-        </form>
+        <IconButton
+          icon={faXmark}
+          className="md:hidden"
+          onClick={() => onShowConfirmModal(watchedValues)}
+        />
       </div>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-10">
+          <div className="flex flex-col gap-6">
+            <TextInput<TodoFormValues>
+              name="title"
+              label="할일 제목"
+              placeholder="할일의 제목을 작성하세요"
+              control={control}
+              errors={errors}
+            />
+            <DateInput<TodoFormValues>
+              name="date"
+              label="날짜"
+              control={control}
+            />
+            <DropDownInput<TodoFormValues>
+              name="goal"
+              label="목표"
+              placeholder="목표를 선택해주세요"
+              options={goalList}
+              control={control}
+              isLoading={isLoading}
+            />
+          </div>
+          <div className="flex w-full flex-row gap-2">
+            <Button
+              size="full"
+              onClick={() => onShowConfirmModal(watchedValues)}
+              className="hidden bg-gs100 py-4 text-gs600 hover:bg-gs100 focus:bg-gs100 active:bg-gs100 md:block"
+            >
+              취소
+            </Button>
+            <Button
+              size="full"
+              type="submit"
+              disabled={!isValid}
+              className={cn('py-4')}
+            >
+              확인
+            </Button>
+          </div>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -127,7 +127,9 @@ export const deleteNote = async (noteId: number) => {
 
 // 목표별 노트 리스트 가져오기
 export async function getNotes(goalId: number) {
-  const res = await fetch(`/api/notes?goalId=${goalId}`);
+  const res = await fetch(`/api/notes?goalId=${goalId}`, {
+    method: 'GET',
+  });
 
   if (!res.ok) {
     throw new Error('Failed to fetch notes');


### PR DESCRIPTION

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝
캘린더 페이지 모달창/노트 보기 모바일에서 전체 페이지로 보여지게 변경

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 모달 창의 레이아웃이 개선되어, 소형 화면에서는 더욱 적절한 폭으로 조정되고, 중간 및 큰 화면에서는 기존 디자인을 유지하도록 반응형 스타일이 업데이트되었습니다.
- **새로운 기능**
  - 모바일 환경에 최적화된 아이콘 기반 취소 버튼이 도입되어 사용자 인터페이스가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->