### PR TITLE
[CAN-68/fix] 캘린더 페이지 오류 수정

### DIFF
--- a/src/components/todoCalendar/CreateTodo.tsx
+++ b/src/components/todoCalendar/CreateTodo.tsx
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { useState } from 'react';
 import TextInput from '@/components/common/input/TextInput';
 import DropDownInput from '@/components/common/input/DropDownInput';
 import DateInput from '../common/input/DateInput';
@@ -44,8 +45,13 @@ export default function CreateTodo({
   const { data: goalList, isLoading } = useGoals();
   const { mutate: addTodo } = useAddTodo();
   const { mutate: updateTodo } = useUpdateTodo();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const onSubmit = async (formData: TodoFormValues) => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+
     if (isEdit && todoId) {
       updateTodo(
         {

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -6,7 +6,7 @@ import Calendar from './Calendar';
 import TodoList from './TodoList';
 import TodoModal from './TodoModal';
 import Loading from '../common/Loading';
-import { useDailyTodos, useMonthlyTodos } from '@/hooks/useTodos';
+import { useMonthlyTodos } from '@/hooks/useTodos';
 
 export default function TodoCalendar() {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
@@ -27,11 +27,6 @@ export default function TodoCalendar() {
     isLoading,
     error,
   } = useMonthlyTodos(currentYear, currentMonth);
-
-  // 하루 단위 할 일
-  const { data: dailyTodos } = useDailyTodos(
-    selectedDate.toLocaleDateString('sv-SE'),
-  );
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
@@ -94,7 +89,6 @@ export default function TodoCalendar() {
           >
             <TodoList
               selectedDate={selectedDate}
-              todos={dailyTodos}
               onOpenModal={handleOpenModal}
             />
           </div>

--- a/src/components/todoCalendar/TodoList.tsx
+++ b/src/components/todoCalendar/TodoList.tsx
@@ -48,10 +48,10 @@ export default function TodoList({ selectedDate, onOpenModal }: Props) {
           )}
         >
           <h3 className="mb-2 text-14M text-gs500">
-            미완료({incompleteTodos?.length || 0})
+            미완료({incompleteTodos.length})
           </h3>
           <div className="h-full">
-            {isFetching && <SimpleTodoSkeleton />}
+            {isFetching && <SimpleTodoSkeleton repeat={3} />}
             {!isFetching && incompleteTodos.length > 0 ? (
               <TodoListItem todoList={incompleteTodos} />
             ) : (
@@ -86,7 +86,7 @@ export default function TodoList({ selectedDate, onOpenModal }: Props) {
           </div>
           {isCompletedOpen && (
             <div className="h-full overflow-y-auto">
-              {isFetching && <SimpleTodoSkeleton />}
+              {isFetching && <SimpleTodoSkeleton repeat={3} />}
               {!isFetching && completeTodos.length > 0 ? (
                 <TodoListItem todoList={completeTodos} />
               ) : (

--- a/src/components/todoCalendar/TodoList.tsx
+++ b/src/components/todoCalendar/TodoList.tsx
@@ -1,29 +1,33 @@
 import { faAngleUp, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useState } from 'react';
-import { Todo } from '@/types/todos';
 import TodoListItem from './TodoListItem';
 import Button from '../common/button/Button';
 import Icon from '../common/icon/Icon';
 import cn from '@/utils/cn';
+import { useDailyTodos } from '@/hooks/useTodos';
+import SimpleTodoSkeleton from '../common/todo/SimpleTodoSkeleton';
 
 interface Props {
   selectedDate: Date;
-  todos: Todo[];
   onOpenModal: () => void;
 }
 
 /**
  * 각 날짜의 할 일 목록을 보여주는 컴포넌트
  * @param selectedDate 선택한 날짜
- * @param todos 해당 날짜에 해당하는 할 일
  * @param onToggleTodo 할 일 토글 버튼(완료/미완료)
  */
-export default function TodoList({ selectedDate, todos, onOpenModal }: Props) {
+export default function TodoList({ selectedDate, onOpenModal }: Props) {
+  // 하루 단위 할 일
+  const { data: todos, isFetching } = useDailyTodos(
+    selectedDate.toLocaleDateString('sv-SE'),
+  );
+
   const [isCompletedOpen, setIsCompletedOpen] = useState(true);
 
-  const incompleteTodos = todos.filter((todo) => !todo.done);
-  const completeTodos = todos.filter((todo) => todo.done);
+  const incompleteTodos = todos ? todos.filter((todo) => !todo.done) : [];
+  const completeTodos = todos ? todos.filter((todo) => todo.done) : [];
 
   return (
     <div className="flex size-full flex-col rounded-[20px] border-2 border-gs200 bg-gs00">
@@ -39,15 +43,16 @@ export default function TodoList({ selectedDate, todos, onOpenModal }: Props) {
         {/* 미완료 */}
         <div
           className={cn(
-            'flex min-h-0 flex-1 flex-col transition-all duration-500 ease-in-out',
+            'flex min-h-0 flex-1 flex-col overflow-y-auto transition-all duration-500 ease-in-out',
             isCompletedOpen ? 'max-h-[50%]' : 'max-h-[85%]',
           )}
         >
           <h3 className="mb-2 text-14M text-gs500">
-            미완료({incompleteTodos.length})
+            미완료({incompleteTodos?.length || 0})
           </h3>
-          <div className="h-full overflow-y-auto">
-            {incompleteTodos.length > 0 ? (
+          <div className="h-full">
+            {isFetching && <SimpleTodoSkeleton />}
+            {!isFetching && incompleteTodos.length > 0 ? (
               <TodoListItem todoList={incompleteTodos} />
             ) : (
               <div className="flex h-full items-center justify-center text-center text-14M text-gs500">
@@ -66,7 +71,7 @@ export default function TodoList({ selectedDate, todos, onOpenModal }: Props) {
         >
           <div className="flex justify-between">
             <h3 className="mb-2 text-14M text-gs500">
-              완료 ({completeTodos.length})
+              완료 ({completeTodos?.length || 0})
             </h3>
             <button
               type="button"
@@ -81,7 +86,8 @@ export default function TodoList({ selectedDate, todos, onOpenModal }: Props) {
           </div>
           {isCompletedOpen && (
             <div className="h-full overflow-y-auto">
-              {completeTodos.length > 0 ? (
+              {isFetching && <SimpleTodoSkeleton />}
+              {!isFetching && completeTodos.length > 0 ? (
                 <TodoListItem todoList={completeTodos} />
               ) : (
                 <div className="flex h-full items-center justify-center text-center text-14M text-gs500">


### PR DESCRIPTION

## 개요 🔎
`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝
- 할 일 생성 시 엔터 여러번 연타 시 생성 여러개 되는 이슈 해결
- 할일 목록이 로딩중에 "할일이 없습니다" 멘트가 나오게 되어 스켈레톤 ui 도입

> Todo
checkTodo에서 수정,삭제 메뉴창이 내부 스크롤때문에 밑에 생기는 문제를 해결해야함
-> 시간 남으면 해보겠습니다,,,,,

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 작업 달력에서 일일 항목 표시를 제거하여 일정 관리를 간소화했습니다.
  - 투두 목록에서 미완료 항목 개수 표시 및 로딩 상태를 개선해 사용자 인터페이스를 향상시켰습니다.
  
- **Bug Fixes**
  - 투두 생성 시 중복 제출을 방지하여 작업 등록 프로세스를 안정화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->