### PR TITLE
[CAN-70/feat] 노트 수정 페이지 기능 구현

### DIFF
--- a/src/app/(member)/note/[noteId]/edit/page.tsx
+++ b/src/app/(member)/note/[noteId]/edit/page.tsx
@@ -1,4 +1,4 @@
-import NoteEditor from '@/components/note/NoteEditor';
+import NoteEditor from '@/components/note/noteCreate/NoteEditor';
 
 export default function page() {
   return <NoteEditor isEditMode />;

--- a/src/app/(member)/note/[noteId]/edit/page.tsx
+++ b/src/app/(member)/note/[noteId]/edit/page.tsx
@@ -1,3 +1,5 @@
+import NoteEditor from '@/components/note/NoteEditor';
+
 export default function page() {
-  return <div>수정페이지</div>;
+  return <NoteEditor isEditMode />;
 }

--- a/src/app/api/notes/[noteId]/route.ts
+++ b/src/app/api/notes/[noteId]/route.ts
@@ -48,3 +48,27 @@ export async function DELETE(
 
   return res2;
 }
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { noteId: number } },
+) {
+  const { noteId } = params;
+  const body = await req.json();
+  const { title, content, linkUrl } = body;
+
+  const res1 = await fetchIntance({
+    base: 'CODEIT',
+    method: 'PATCH',
+    url: `/notes/${noteId}`,
+    body: {
+      title,
+      content,
+      linkUrl,
+    },
+  });
+
+  if (!res1.ok) return res1;
+
+  return res1;
+}

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -39,7 +39,9 @@ export default function ConfirmModal({
             </div>
           </div>
           <span className="text-18M">{title}</span>
-          <span className="text-14M text-gs400">{description}</span>
+          <span className="whitespace-pre-line text-center text-14M text-gs400">
+            {description}
+          </span>
         </div>
         <div className="flex w-full flex-row gap-2">
           <Button

--- a/src/components/note/noteCreate/NoteEditor.tsx
+++ b/src/components/note/noteCreate/NoteEditor.tsx
@@ -81,6 +81,10 @@ export default function NoteEditor({
 
   // 노트 저장 함수
   const onSubmit = async (formData: NoteSchemaType) => {
+    // const storedData = localStorage.getItem(`todo-${todoId}`);
+    localStorage.removeItem(`todo-${todoId}`);
+    // if (storedData) {
+    // }
     if (!isEditMode) {
       try {
         const res = await createNote({
@@ -220,7 +224,8 @@ export default function NoteEditor({
       setValue('content', editNoteData.content || '');
       setValue('linkUrl', editNoteData.linkUrl || '');
       trigger();
-    } else if (typeof window !== 'undefined') {
+    }
+    if (typeof window !== 'undefined') {
       const storedData = localStorage.getItem(`todo-${todoId}`);
       setSavedData(storedData);
       setShowSavedData(!!storedData);

--- a/src/components/note/noteCreate/NoteEditor.tsx
+++ b/src/components/note/noteCreate/NoteEditor.tsx
@@ -81,10 +81,7 @@ export default function NoteEditor({
 
   // 노트 저장 함수
   const onSubmit = async (formData: NoteSchemaType) => {
-    // const storedData = localStorage.getItem(`todo-${todoId}`);
     localStorage.removeItem(`todo-${todoId}`);
-    // if (storedData) {
-    // }
     if (!isEditMode) {
       try {
         const res = await createNote({

--- a/src/components/note/noteCreate/NoteEditor.tsx
+++ b/src/components/note/noteCreate/NoteEditor.tsx
@@ -11,7 +11,7 @@ import { faFontAwesome } from '@fortawesome/free-solid-svg-icons';
 import { NoteSchema, NoteSchemaType } from '@/lib/note-validation';
 import NoteContentEditor from './NoteContentEditor';
 import NoteTitle from './NoteTitle';
-import { createNote } from '@/services/note';
+import { createNote, editNote } from '@/services/note';
 import { useTodoWithGoalTitle } from '@/hooks/useTodoWithGoalTitle';
 import NoteTitlesSkeleton from './NoteTitlesSkeleton';
 import ConfirmModal from '../../common/ConfirmModal';
@@ -20,10 +20,22 @@ import TempSaveNotification from './TempSaveNotification';
 import NoteEditHeader from './NoteEditHeader';
 import Icon from '../../common/icon/Icon';
 import cn from '@/utils/cn';
+import { useNoteDetail } from '@/hooks/useNotes';
 
-export default function NoteEditor() {
-  const { todoId } = useParams<{ todoId: string }>();
+export default function NoteEditor({
+  isEditMode = false,
+}: {
+  isEditMode?: boolean;
+}) {
+  const params = useParams();
   const router = useRouter();
+
+  const noteId = isEditMode ? Number(params.noteId) : null;
+  const { data: editNoteData } = useNoteDetail(noteId);
+
+  const todoId = !isEditMode
+    ? String(params.todoId)
+    : String(editNoteData?.todo.todoId);
   // 할 일 제목, 목표 제목 가져오기
   const { todoQuery, goalQuery } = useTodoWithGoalTitle(todoId);
 
@@ -50,8 +62,6 @@ export default function NoteEditor() {
   const [embedUrl, setEmbedUrl] = useState(linkUrl);
   // 임베드 보기 여부
   const [embedVisible, setEmbedVisible] = useState(false);
-  // 노트 수정하기 상태
-  const [isEditMode, setIsEditMode] = useState(false);
 
   // 임시저장 데이터
   const [savedData, setSavedData] = useState<string | null>(null);
@@ -71,7 +81,7 @@ export default function NoteEditor() {
 
   // 노트 저장 함수
   const onSubmit = async (formData: NoteSchemaType) => {
-    if (todoId) {
+    if (!isEditMode) {
       try {
         const res = await createNote({
           todoId: Number(todoId),
@@ -86,6 +96,21 @@ export default function NoteEditor() {
 
         toast.success(res?.data.message);
         router.back(); // 이전 페이지로 이동
+      } catch {
+        toast.error('노트 생성 중 알 수 없는 오류가 발생했습니다.');
+      }
+    } else {
+      if (!noteId) return;
+      try {
+        const res = await editNote({ noteId, formData });
+        if (!res.data) {
+          const errorMessage = res?.message;
+          toast.error(errorMessage);
+          return;
+        }
+
+        toast.success('노트 수정이 완료되었습니다.');
+        router.back();
       } catch {
         toast.error('노트 생성 중 알 수 없는 오류가 발생했습니다.');
       }
@@ -188,17 +213,19 @@ export default function NoteEditor() {
   }, [handleTempSave]);
 
   useEffect(() => {
-    setIsEditMode(false);
     // 노트 수정하기
-    if (isEditMode) {
+    if (isEditMode && editNoteData) {
       // 기존 노트 데이터 가져오기
-      //
+      setValue('title', editNoteData.title || '');
+      setValue('content', editNoteData.content || '');
+      setValue('linkUrl', editNoteData.linkUrl || '');
+      trigger();
     } else if (typeof window !== 'undefined') {
       const storedData = localStorage.getItem(`todo-${todoId}`);
       setSavedData(storedData);
       setShowSavedData(!!storedData);
     }
-  }, [todoId, isEditMode, setTempData]);
+  }, [todoId, isEditMode, setTempData, editNoteData, setValue, trigger]);
 
   // 링크 URL 변경 시 임베드 URL 업데이트
   useEffect(() => {

--- a/src/components/note/noteDetail/NoteDetail.tsx
+++ b/src/components/note/noteDetail/NoteDetail.tsx
@@ -17,6 +17,7 @@ import SkeletonNoteModal from './SkeletonNoteModal';
 import Icon from '../../common/icon/Icon';
 import cn from '@/utils/cn';
 import EmbedPreview from '../noteCreate/EmbedPreview';
+import ConfirmModal from '@/components/common/ConfirmModal';
 
 const goalColor: Record<string, string> = {
   goal01: 'text-goal01',
@@ -49,6 +50,7 @@ export default function NoteDetail({
   const { mutate: deleteNote } = useDeleteNote();
 
   const [embedVisible, setEmbedVisible] = useState(embedVisibleProp ?? false);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   useEffect(() => {
     if (note?.content) {
@@ -66,12 +68,17 @@ export default function NoteDetail({
     }
   };
 
-  const handleDelete = () => {
+  const handleDeleteButton = () => {
+    setShowConfirm(true);
+  };
+
+  const handleConfirmDelete = () => {
     deleteNote(noteId, {
       onSuccess: () => {
         router.back();
       },
     });
+    setShowConfirm(false);
   };
 
   const handleBack = () => {
@@ -170,7 +177,7 @@ export default function NoteDetail({
                     <button
                       type="button"
                       className="flex whitespace-nowrap px-4 py-2 text-14R text-gs700 hover:bg-gs200"
-                      onClick={handleDelete}
+                      onClick={handleDeleteButton}
                     >
                       삭제하기
                     </button>
@@ -218,6 +225,15 @@ export default function NoteDetail({
           </div>
         </div>
       </div>
+      {showConfirm && (
+        <ConfirmModal
+          title="노트를 삭제 하시겠어요?"
+          description="작성된 내용이 모두 사라지고 복구할 수 없습니다."
+          confirmText="지우기"
+          onCancel={() => setShowConfirm(false)}
+          onConfirm={handleConfirmDelete}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/note/noteDetail/NoteDetail.tsx
+++ b/src/components/note/noteDetail/NoteDetail.tsx
@@ -169,14 +169,14 @@ export default function NoteDetail({
                   >
                     <button
                       type="button"
-                      className="flex whitespace-nowrap px-4 py-2 text-14R text-gs700 hover:bg-gs200"
+                      className="flex whitespace-nowrap rounded px-4 py-2 text-14R text-gs700 hover:bg-gs200"
                       onClick={handleEdit}
                     >
                       수정하기
                     </button>
                     <button
                       type="button"
-                      className="flex whitespace-nowrap px-4 py-2 text-14R text-gs700 hover:bg-gs200"
+                      className="flex whitespace-nowrap rounded px-4 py-2 text-14R text-gs700 hover:bg-gs200"
                       onClick={handleDeleteButton}
                     >
                       삭제하기

--- a/src/components/todoCalendar/CreateTodo.tsx
+++ b/src/components/todoCalendar/CreateTodo.tsx
@@ -90,7 +90,7 @@ export default function CreateTodo({
   const watchedValues = watch();
 
   return (
-    <div className="flex h-full w-[520px] flex-col gap-6 bg-gs00 p-6 md:h-auto md:rounded-lg">
+    <div className="flex size-full flex-col gap-6 bg-gs00 p-6 md:h-auto md:w-[520px] md:rounded-lg">
       <div className="flex justify-between">
         <h2 className="text-18SB">{isEdit ? '할일 수정' : '할일 생성'}</h2>
         <IconButton

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -3,10 +3,11 @@ import { QUERY_KEY } from '@/constants/queryKey';
 import { getNoteDetail, getNotes, deleteNote } from '@/services/note';
 import { NoteDetail } from '@/types/note';
 
-export const useNoteDetail = (noteId: number) => {
+export const useNoteDetail = (noteId?: number | null) => {
   return useQuery<NoteDetail>({
     queryKey: [QUERY_KEY.NOTE, noteId],
-    queryFn: () => getNoteDetail(noteId),
+    queryFn: () => getNoteDetail(noteId!),
+    enabled: !!noteId,
   });
 };
 

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -138,3 +138,34 @@ export async function getNotes(goalId: number) {
   const data = await res.json();
   return data.notes;
 }
+
+export const editNote = async ({
+  formData,
+  noteId,
+}: {
+  formData: {
+    title: string;
+    content: string;
+    linkUrl: string;
+  };
+  noteId: number;
+}) => {
+  try {
+    const res = await fetch(`/api/notes/${noteId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        title: formData.title,
+        content: formData.content,
+        linkUrl: formData.linkUrl || null,
+      }),
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+      return data;
+    }
+    return { data };
+  } catch (error) {
+    return error;
+  }
+};


### PR DESCRIPTION

## 개요 🔎
`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝
- 노트 수정 페이지 생성 컴포넌트 재사용
- API 연동까지 완료

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 노트 삭제 시, 사용자 확인을 위한 모달이 추가되어 삭제 작업의 안전성이 향상되었습니다.
  - 노트 편집 페이지가 개선되어 기존 노트 데이터를 불러와 수정할 수 있는 인터랙티브 편집 모드가 도입되었습니다.
  - 노트 업데이트 기능이 강화되어 보다 원활한 노트 관리가 가능합니다.

- **Style**
  - 삭제 및 편집 버튼에 라운드 스타일이 적용되어 시각적 일관성이 개선되었습니다.
  - Todo 생성 화면과 확인 모달의 레이아웃이 개선되어 반응형 디자인이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->