### PR TITLE
[CAN-59/feat] 노트 단일 조회 페이지 링크 임베드 적용

### DIFF
--- a/src/components/note/noteCreate/EmbedPreview.tsx
+++ b/src/components/note/noteCreate/EmbedPreview.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { faClose } from '@fortawesome/free-solid-svg-icons';
 import Icon from '../../common/icon/Icon';
 
@@ -6,16 +6,35 @@ type Props = {
   embedUrl: string;
   embedVisible: boolean;
   onClose: () => void;
-  fallback: boolean;
 };
 
 export default function EmbedPreview({
   embedUrl,
   embedVisible,
   onClose,
-  fallback,
 }: Props) {
+  // 오브젝트 대체
+  const [fallback, setFallback] = useState(false);
   const objectRef = useRef<HTMLObjectElement | null>(null);
+
+  useEffect(() => {
+    if (!embedUrl || !embedVisible) return undefined;
+
+    const objectEl = objectRef.current;
+    if (!objectEl) return undefined;
+
+    const timer = setTimeout(() => {
+      if (
+        objectEl &&
+        (objectEl.clientWidth === 0 || objectEl.clientHeight === 0)
+      ) {
+        // iframe 대체
+        setFallback(true);
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [embedUrl, embedVisible]);
 
   if (!embedVisible || !embedUrl) return null;
 

--- a/src/components/note/noteCreate/LinkModal.tsx
+++ b/src/components/note/noteCreate/LinkModal.tsx
@@ -55,7 +55,7 @@ export default function LinkModal({ onClose, setValue }: Props) {
               rules={{
                 required: '링크를 입력해주세요',
                 pattern: {
-                  value: /^(http|https):\/\/[\w]+(\.[\w]+)+[/#?]?.*$/,
+                  value: /^(https?:\/\/)[\w.-]+(?:\.[\w.-]+)+(\/\S*)?$/,
                   message: '유효한 URL을 입력해주세요',
                 },
               }}

--- a/src/components/note/noteCreate/NoteEditor.tsx
+++ b/src/components/note/noteCreate/NoteEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import 'react-quill-new/dist/quill.snow.css';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -24,10 +24,6 @@ import cn from '@/utils/cn';
 export default function NoteEditor() {
   const { todoId } = useParams<{ todoId: string }>();
   const router = useRouter();
-  // 오브젝트 (임베드)
-  const objectRef = useRef<HTMLObjectElement | null>(null);
-  // 오브젝트 대체
-  const [fallback, setFallback] = useState(false);
   // 할 일 제목, 목표 제목 가져오기
   const { todoQuery, goalQuery } = useTodoWithGoalTitle(todoId);
 
@@ -182,24 +178,6 @@ export default function NoteEditor() {
     }
   };
 
-  // object 지원 체크
-  const checkEmbedUrl = useCallback(() => {
-    const objectEl = objectRef.current;
-    if (!objectEl) {
-      return;
-    }
-
-    setTimeout(() => {
-      if (
-        objectEl &&
-        (objectEl.clientWidth === 0 || objectEl.clientHeight === 0)
-      ) {
-        // iframe 대체
-        setFallback(true);
-      }
-    }, 500);
-  }, []);
-
   // 자동 임시 저장 기능(5분마다)
   useEffect(() => {
     const interval = setInterval(() => {
@@ -233,7 +211,6 @@ export default function NoteEditor() {
       <EmbedPreview
         embedUrl={embedUrl}
         embedVisible={embedVisible}
-        fallback={fallback}
         onClose={() => setEmbedVisible(false)}
       />
 
@@ -305,7 +282,6 @@ export default function NoteEditor() {
             setValue={setValue}
             isValid={isValid}
             setEmbedVisible={setEmbedVisible}
-            checkEmbedUrl={checkEmbedUrl}
           />
         </div>
       </form>

--- a/src/components/note/noteDetail/NoteDetail.tsx
+++ b/src/components/note/noteDetail/NoteDetail.tsx
@@ -106,7 +106,7 @@ export default function NoteDetail({
       )}
     >
       {embedVisible && embedUrl && (
-        <div className="relative flex flex-col bg-gray-100 lg:w-1/2">
+        <div className="relative flex h-2/5 flex-col bg-gray-100 lg:h-full lg:w-1/2">
           {/* 닫기 버튼 */}
           <IconButton
             className="absolute right-2 top-2 rounded-full bg-white p-2"

--- a/src/components/note/noteDetail/NoteDetail.tsx
+++ b/src/components/note/noteDetail/NoteDetail.tsx
@@ -3,13 +3,13 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faArrowLeft,
+  faClose,
   faEllipsisVertical,
   faFlag,
   faLink,
 } from '@fortawesome/free-solid-svg-icons';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
 import DOMPurify from 'dompurify';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import IconButton from '../../common/button/IconButton';
@@ -27,10 +27,18 @@ const goalColor: Record<string, string> = {
 interface Props {
   noteId: number;
   isModal?: boolean;
+  embedVisible?: boolean;
+  setEmbedVisible?: (visible: boolean) => void;
   setIsClosing?: (value: boolean) => void;
 }
 
-export default function NoteDetail({ noteId, isModal, setIsClosing }: Props) {
+export default function NoteDetail({
+  noteId,
+  isModal,
+  embedVisible: embedVisibleProp,
+  setEmbedVisible: setEmbedVisibleProp,
+  setIsClosing,
+}: Props) {
   const router = useRouter();
   const [sanitizedContent, setSanitizedContent] = useState<string | null>(null);
 
@@ -40,11 +48,17 @@ export default function NoteDetail({ noteId, isModal, setIsClosing }: Props) {
   const { data: note, isLoading, error } = useNoteDetail(noteId);
   const { mutate: deleteNote } = useDeleteNote();
 
+  const [embedUrl, setEmbedUrl] = useState<string | null>(null);
+  const [embedVisible, setEmbedVisible] = useState(embedVisibleProp ?? false);
+
   useEffect(() => {
     if (note?.content) {
       setSanitizedContent(DOMPurify.sanitize(note.content));
     }
-  }, [note?.content]);
+    if (note?.linkUrl) {
+      setEmbedUrl(note.linkUrl);
+    }
+  }, [note?.content, note?.linkUrl]);
 
   const handleEdit = () => {
     if (setIsClosing) {
@@ -83,100 +97,138 @@ export default function NoteDetail({ noteId, isModal, setIsClosing }: Props) {
 
   return (
     <div
-      className={cn('h-full overflow-y-auto bg-gs00', {
-        'rounded-2xl border-2 border-gs200': !isModal,
-      })}
+      className={cn(
+        'h-full overflow-y-auto bg-gs00',
+        {
+          'rounded-2xl border-2 border-gs200': !isModal,
+        },
+        { 'lg:flex': embedVisible },
+      )}
     >
-      {!isModal && (
-        <div className="flex w-full gap-2 border-b-2 border-gs200 bg-gs50 p-4">
-          <IconButton icon={faArrowLeft} onClick={handleBack} />
-          <h1 className="text-18SB text-gsBk">노트</h1>
+      {embedVisible && embedUrl && (
+        <div className="relative flex flex-col bg-gray-100 lg:w-1/2">
+          {/* 닫기 버튼 */}
+          <IconButton
+            className="absolute right-2 top-2 rounded-full bg-white p-2"
+            icon={faClose}
+            onClick={() => {
+              if (setEmbedVisibleProp) {
+                setEmbedVisibleProp(false);
+              }
+              setEmbedVisible(false);
+            }}
+          />
+          <iframe
+            src={embedUrl}
+            className="size-full rounded-lg"
+            title="Embedded Content"
+            sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
+            referrerPolicy="no-referrer"
+          />
         </div>
       )}
       <div
-        className={cn('flex grow flex-col gap-6 px-6', {
-          'pt-6': !isModal,
+        className={cn('flex grow flex-col', {
+          'lg:w-1/2': embedVisible,
         })}
       >
-        <div className="flex flex-col gap-3">
-          <div className="flex justify-between">
-            {/* 목표 제목 */}
-            {note.todo.goal && (
-              <div className="flex items-center justify-between">
-                <h1 className="flex items-center gap-3 text-16M">
-                  <Icon
-                    icon={faFlag}
-                    className={cn(
-                      goalColor[note.todo.goal?.color || 'default'],
-                    )}
-                  />
-                  {note.todo.goal?.title}
-                </h1>
-              </div>
-            )}
-            <div className="relative">
-              <IconButton
-                className="bg-gs00 text-gs400"
-                icon={faEllipsisVertical}
-                onClick={() => {
-                  setIsMenuOpen(true);
-                }}
-              />
-              {isMenuOpen && (
-                <div
-                  className="absolute right-0 z-10 mt-2 rounded bg-gs00 shadow-md"
-                  ref={menuRef}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <button
-                    type="button"
-                    className="flex whitespace-nowrap px-4 py-2 text-14R text-gs700 hover:bg-gs200"
-                    onClick={handleEdit}
-                  >
-                    수정하기
-                  </button>
-                  <button
-                    type="button"
-                    className="flex whitespace-nowrap px-4 py-2 text-14R text-gs700 hover:bg-gs200"
-                    onClick={handleDelete}
-                  >
-                    삭제하기
-                  </button>
+        {!isModal && (
+          <div className="flex w-full gap-2 border-b-2 border-gs200 bg-gs50 p-4">
+            <IconButton icon={faArrowLeft} onClick={handleBack} />
+            <h1 className="text-18SB text-gsBk">노트</h1>
+          </div>
+        )}
+        <div
+          className={cn('flex grow flex-col gap-6 px-6', {
+            'pt-6': !isModal,
+          })}
+        >
+          <div className="flex flex-col gap-3">
+            <div className="flex justify-between">
+              {/* 목표 제목 */}
+              {note.todo.goal && (
+                <div className="flex items-center justify-between">
+                  <h1 className="flex items-center gap-3 text-16M">
+                    <Icon
+                      icon={faFlag}
+                      className={cn(
+                        goalColor[note.todo.goal?.color || 'default'],
+                      )}
+                    />
+                    {note.todo.goal?.title}
+                  </h1>
                 </div>
               )}
+              <div className="relative">
+                <IconButton
+                  className="bg-gs00 text-gs400"
+                  icon={faEllipsisVertical}
+                  onClick={() => {
+                    setIsMenuOpen(true);
+                  }}
+                />
+                {isMenuOpen && (
+                  <div
+                    className="absolute right-0 z-10 mt-2 rounded bg-gs00 shadow-md"
+                    ref={menuRef}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      type="button"
+                      className="flex whitespace-nowrap px-4 py-2 text-14R text-gs700 hover:bg-gs200"
+                      onClick={handleEdit}
+                    >
+                      수정하기
+                    </button>
+                    <button
+                      type="button"
+                      className="flex whitespace-nowrap px-4 py-2 text-14R text-gs700 hover:bg-gs200"
+                      onClick={handleDelete}
+                    >
+                      삭제하기
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* To do */}
+            <div className="flex items-center gap-2 text-gs700">
+              <span className="rounded bg-gs200 p-1 text-12M">To do</span>
+              <span className="text-14R">{note.todo.title}</span>
+              <span className="ml-auto text-12R">{note.updatedAt}</span>
             </div>
           </div>
 
-          {/* To do */}
-          <div className="flex items-center gap-2 text-gs700">
-            <span className="rounded bg-gs200 p-1 text-12M">To do</span>
-            <span className="text-14R">{note.todo.title}</span>
-            <span className="ml-auto text-12R">{note.updatedAt}</span>
-          </div>
-        </div>
+          <div className="flex flex-col gap-4">
+            {/* 노트 제목 */}
+            <div className="flex items-center justify-between border-y py-3">
+              <h1 className="flex items-center text-18M">{note.title}</h1>
+            </div>
+            {note.linkUrl && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-3xl bg-gs200 px-2 py-1"
+                onClick={() => {
+                  if (setEmbedVisibleProp) {
+                    setEmbedVisibleProp(true);
+                  }
+                  setEmbedVisible(true);
+                }}
+              >
+                <div className="flex size-6 flex-none items-center justify-center rounded-full bg-slate500">
+                  <FontAwesomeIcon icon={faLink} className="size-3 text-gs00" />
+                </div>
+                <p className="truncate text-16M">{note.linkUrl}</p>
+              </button>
+            )}
 
-        <div className="flex flex-col gap-4">
-          {/* 노트 제목 */}
-          <div className="flex items-center justify-between border-y py-3">
-            <h1 className="flex items-center text-18M">{note.title}</h1>
+            {/* 내용 */}
+            <div
+              className="whitespace-pre-line text-16R text-gs700"
+              dangerouslySetInnerHTML={{ __html: sanitizedContent || '' }}
+            />
           </div>
-          {note.linkUrl && (
-            <Link
-              href={note.linkUrl}
-              className="flex w-full items-center gap-2 rounded-3xl bg-gs200 px-2 py-1"
-            >
-              <div className="flex size-6 flex-none items-center justify-center rounded-full bg-slate500">
-                <FontAwesomeIcon icon={faLink} className="size-3 text-gs00" />
-              </div>
-              <p className="truncate text-16M">{note.linkUrl}</p>
-            </Link>
-          )}
-
-          {/* 내용 */}
-          <div
-            className="whitespace-pre-line text-16R text-gs700"
-            dangerouslySetInnerHTML={{ __html: sanitizedContent || '' }}
-          />
         </div>
       </div>
     </div>

--- a/src/components/note/noteDetail/NoteDetail.tsx
+++ b/src/components/note/noteDetail/NoteDetail.tsx
@@ -3,7 +3,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faArrowLeft,
-  faClose,
   faEllipsisVertical,
   faFlag,
   faLink,
@@ -17,6 +16,7 @@ import { useDeleteNote, useNoteDetail } from '@/hooks/useNotes';
 import SkeletonNoteModal from './SkeletonNoteModal';
 import Icon from '../../common/icon/Icon';
 import cn from '@/utils/cn';
+import EmbedPreview from '../noteCreate/EmbedPreview';
 
 const goalColor: Record<string, string> = {
   goal01: 'text-goal01',
@@ -48,15 +48,11 @@ export default function NoteDetail({
   const { data: note, isLoading, error } = useNoteDetail(noteId);
   const { mutate: deleteNote } = useDeleteNote();
 
-  const [embedUrl, setEmbedUrl] = useState<string | null>(null);
   const [embedVisible, setEmbedVisible] = useState(embedVisibleProp ?? false);
 
   useEffect(() => {
     if (note?.content) {
       setSanitizedContent(DOMPurify.sanitize(note.content));
-    }
-    if (note?.linkUrl) {
-      setEmbedUrl(note.linkUrl);
     }
   }, [note?.content, note?.linkUrl]);
 
@@ -105,31 +101,22 @@ export default function NoteDetail({
         { 'lg:flex': embedVisible },
       )}
     >
-      {embedVisible && embedUrl && (
-        <div className="relative flex h-2/5 flex-col bg-gray-100 lg:h-full lg:w-1/2">
-          {/* 닫기 버튼 */}
-          <IconButton
-            className="absolute right-2 top-2 rounded-full bg-white p-2"
-            icon={faClose}
-            onClick={() => {
-              if (setEmbedVisibleProp) {
-                setEmbedVisibleProp(false);
-              }
-              setEmbedVisible(false);
-            }}
-          />
-          <iframe
-            src={embedUrl}
-            className="size-full rounded-lg"
-            title="Embedded Content"
-            sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
-            referrerPolicy="no-referrer"
-          />
-        </div>
+      {note.linkUrl && (
+        <EmbedPreview
+          embedUrl={note.linkUrl}
+          embedVisible={embedVisible}
+          onClose={() => {
+            if (setEmbedVisibleProp) {
+              setEmbedVisibleProp(false);
+            }
+            setEmbedVisible(false);
+          }}
+        />
       )}
+
       <div
         className={cn('flex grow flex-col', {
-          'lg:w-1/2': embedVisible,
+          'md:w-1/4': embedVisible,
         })}
       >
         {!isModal && (
@@ -146,8 +133,8 @@ export default function NoteDetail({
           <div className="flex flex-col gap-3">
             <div className="flex justify-between">
               {/* 목표 제목 */}
-              {note.todo.goal && (
-                <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between">
+                {note.todo.goal && (
                   <h1 className="flex items-center gap-3 text-16M">
                     <Icon
                       icon={faFlag}
@@ -157,8 +144,8 @@ export default function NoteDetail({
                     />
                     {note.todo.goal?.title}
                   </h1>
-                </div>
-              )}
+                )}
+              </div>
               <div className="relative">
                 <IconButton
                   className="bg-gs00 text-gs400"

--- a/src/components/note/noteDetail/NoteModal.tsx
+++ b/src/components/note/noteDetail/NoteModal.tsx
@@ -8,6 +8,7 @@ import { createPortal } from 'react-dom';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import IconButton from '../../common/button/IconButton';
 import NoteDetail from './NoteDetail';
+import cn from '@/utils/cn';
 
 interface Props {
   noteId: number;
@@ -16,6 +17,7 @@ interface Props {
 export default function NoteModal({ noteId }: Props) {
   const router = useRouter();
   const [isClosing, setIsClosing] = useState(false);
+  const [embedVisible, setEmbedVisible] = useState(false);
 
   const closeModal = () => {
     setIsClosing(true);
@@ -37,7 +39,10 @@ export default function NoteModal({ noteId }: Props) {
           />
           <motion.div
             ref={modalRef}
-            className="fixed inset-y-0 right-0 z-40 flex max-h-full w-full flex-col bg-gs00 pb-6 shadow-lg lg:w-[45%]"
+            className={cn(
+              'fixed inset-y-0 right-0 z-40 flex max-h-full w-full flex-col bg-gs00 pb-6 shadow-lg lg:w-[45%]',
+              { 'lg:w-[80%]': embedVisible },
+            )}
             initial={{ x: '100%' }}
             animate={{ x: 0 }}
             exit={{ x: '100%' }}
@@ -49,7 +54,13 @@ export default function NoteModal({ noteId }: Props) {
               onClick={closeModal}
               icon={faXmark}
             />
-            <NoteDetail noteId={noteId} isModal setIsClosing={setIsClosing} />
+            <NoteDetail
+              noteId={noteId}
+              isModal
+              setIsClosing={setIsClosing}
+              embedVisible={embedVisible}
+              setEmbedVisible={setEmbedVisible}
+            />
           </motion.div>
         </>
       )}

--- a/src/components/note/noteDetail/NoteModal.tsx
+++ b/src/components/note/noteDetail/NoteModal.tsx
@@ -32,7 +32,7 @@ export default function NoteModal({ noteId }: Props) {
       {!isClosing && (
         <>
           <motion.div
-            className="fixed inset-0 z-40 bg-gsBk/50"
+            className="bg-gsBk/50 fixed inset-0 z-40"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -41,7 +41,7 @@ export default function NoteModal({ noteId }: Props) {
             ref={modalRef}
             className={cn(
               'fixed inset-y-0 right-0 z-40 flex max-h-full w-full flex-col bg-gs00 pb-6 shadow-lg lg:w-[45%]',
-              { 'lg:w-[80%]': embedVisible },
+              { 'lg:w-[75%]': embedVisible },
             )}
             initial={{ x: '100%' }}
             animate={{ x: 0 }}

--- a/src/utils/renderNotePage.tsx
+++ b/src/utils/renderNotePage.tsx
@@ -24,7 +24,9 @@ export async function renderNoteDetail(noteId: number, isModal?: boolean) {
         {isModal ? (
           <NoteModal noteId={noteId} />
         ) : (
-          <NoteDetail noteId={noteId} />
+          <div className="h-screen">
+            <NoteDetail noteId={noteId} />
+          </div>
         )}
       </HydrationBoundary>
     );


### PR DESCRIPTION

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

`해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`

## 패키지 설치내용 📦

<img width="1347" alt="image" src="https://github.com/user-attachments/assets/729043de-bcee-4e4b-8177-d30d83c701ea" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 노트 상세 보기 화면의 레이아웃이 업데이트되어, 소형 화면에서 최적의 높이 비율과 안정된 너비를 제공합니다.
  - 노트 페이지에 전체 화면 높이 컨테이너가 적용되어 일관된 레이아웃을 구현합니다.
- **새로운 기능**
  - 노트 상세 보기에서 임베드 미리보기를 관리할 수 있는 기능이 추가되었습니다.
  - 링크 모달에서 URL 유효성 검사 기능이 개선되어 더 다양한 URL 형식을 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->