### PR TITLE
[CAN-73/fix] refresh로직 jwt callback함수로 이동

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -10,23 +10,13 @@ export const authConfig = {
       const isOnLoginPage = nextUrl.pathname.startsWith('/login');
       const isOnSignupPage = nextUrl.pathname.startsWith('/signup');
 
-      // 로그인/회원가입 페이지인 경우
-      if (isOnLoginPage || isOnSignupPage) {
-        // 로그인된 상태
-        if (isLoggedIn) {
-          return Response.redirect(new URL('/', nextUrl)); // 대시보드로 리디렉션
-        }
-        return true; // 로그인 안 했으면 로그인/회원가입 페이지 보여줌
+      // 로그인이 안되어있을 때 로그인, 회원가입 페이지 외의 페이지에 접근할 경우
+      if (!isOnLoginPage && !isOnSignupPage && !isLoggedIn) {
+        return Response.redirect(new URL('/login', nextUrl));
       }
 
-      // 홈(대시보드 페이지)와 그 외 경로 페이지인 경우
-      if (nextUrl.pathname.startsWith('/')) {
-        // 로그인 안 된 상태
-        if (!isLoggedIn) {
-          // return true;
-          return Response.redirect(new URL('/login', nextUrl));
-        }
-        return true; // 로그인된 사용자는 대시보드 페이지 접근 허용
+      if ((isOnLoginPage || isOnSignupPage) && isLoggedIn) {
+        return Response.redirect(new URL('/', nextUrl));
       }
 
       return true; // 그 외의 페이지는 기본적으로 접근 허용

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -100,7 +100,7 @@ export const {
   ],
   session: {
     strategy: 'jwt',
-    maxAge: 60 * 60, // 1시간 후 세션 만료
+    maxAge: 24 * 60 * 60, // 1일 후 세션 만료
   },
   secret: process.env.AUTH_SECRET,
   callbacks: {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,6 +2,34 @@ import NextAuth from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
 import { authConfig } from './auth.config';
 
+// refresh token을 사용하여 access token을 갱신하는 함수
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function refreshAccessToken(token: any) {
+  try {
+    const response = await fetch(
+      `${process.env.BACKEND_API_URL}/auth/refresh`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token?.refreshToken}` },
+        next: { revalidate: 60 },
+      },
+    );
+
+    const refreshedTokens = await response.json();
+    if (response.ok && refreshedTokens) {
+      // 새로 발급된 토큰 정보를 반환
+      return {
+        ...token,
+        accessToken: refreshedTokens.accessToken,
+        accessTokenExpires: Date.now() + 60 * 60 * 1000,
+      };
+    }
+    throw refreshAccessToken;
+  } catch {
+    return { ...token };
+  }
+}
+
 export const {
   auth,
   handlers,
@@ -83,6 +111,7 @@ export const {
           ...token,
           accessToken: user.accessToken,
           refreshToken: user.refreshToken,
+          accessTokenExpires: Date.now() + 60 * 60 * 1000,
         };
       }
 
@@ -93,21 +122,19 @@ export const {
         };
       }
 
-      return token;
+      const accessTokenExpires = token.accessTokenExpires as number;
+      if (Date.now() < accessTokenExpires) return token;
+      return refreshAccessToken(token);
     },
     async session({ session, token }) {
-      if (token?.accessToken) {
-        return {
-          ...session,
-          user: {
-            ...session.user,
-            image: token?.picture || null,
-          },
-          accessToken: token.accessToken,
-          refreshToken: token.refreshToken,
-        };
+      const newSession = { ...session, user: { ...session.user } };
+      if (token) {
+        newSession.user.name = token.name;
+        newSession.user.image = token.picture;
+        newSession.user.email = token.email || '';
+        newSession.accessToken = (token.accessToken as string) || '';
       }
-      return session;
+      return newSession;
     },
   },
 });

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,4 +1,3 @@
-import { auth } from '@/auth';
 import { Props } from '@/components/auth/SignupForm';
 /**
  * 회원가입 함수
@@ -20,31 +19,5 @@ export default async function signup(formData: Props) {
     return { success: response.ok, message: data.message };
   } catch {
     return { success: false, message: '회원가입 요청 중 오류가 발생했습니다.' };
-  }
-}
-const BASE_URL = typeof window === 'undefined' ? 'http://localhost:3001' : '';
-
-export async function getUser() {
-  const session = await auth();
-
-  try {
-    const response = await fetch(`${BASE_URL}/api/auth/settings`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${session?.accessToken}`,
-      },
-      cache: 'no-store',
-    });
-
-    const data = await response.json();
-
-    return { user: data.user, success: response.ok, message: data.message };
-  } catch (e) {
-    console.error('회원정보 조회 요청 중 오류가 발생했습니다.', e);
-    return {
-      success: false,
-      message: '회원정보 조회 요청 중 오류가 발생했습니다.',
-    };
   }
 }

--- a/src/services/fetchInstance.ts
+++ b/src/services/fetchInstance.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { NextResponse } from 'next/server';
-import { auth, update } from '@/auth';
+import { auth } from '@/auth';
 import { ERROR_MESSAGES, getErrorMessage } from '@/constants/errorMessages';
 
 const BASEURL = {
@@ -33,28 +33,6 @@ const getConfig = async <T>(
   }
 
   return { method, headers, body: JSON.stringify(body) };
-};
-
-/**
- * refresh 요청 후 session의 accessToken 업데이트
- * @returns accessToekn 또는 null
- */
-const handleTokenRefresh = async () => {
-  const session = await auth();
-  if (!session?.refreshToken) {
-    return null;
-  }
-
-  const res = await fetch(`${BASEURL.BACKEND}/auth/refresh`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${session?.refreshToken}` },
-  });
-
-  if (!res.ok) return null;
-
-  const data = await res.json();
-  update({ accessToken: data.accessToken });
-  return session.accessToken;
 };
 
 /**
@@ -93,17 +71,8 @@ export const fetchIntance = async <T>(options: {
       baseUrl = `${baseUrl}?${searchParams.toString()}`;
     }
 
-    let config = await getConfig(method, body);
-    let res = await fetch(baseUrl, config);
-
-    // 요청 이후 코드
-    if (res.status === 401) {
-      const newToken = await handleTokenRefresh();
-      if (!newToken) return res;
-
-      config = await getConfig(method, body);
-      res = await fetch(baseUrl, config);
-    }
+    const config = await getConfig(method, body);
+    const res = await fetch(baseUrl, config);
 
     if (!res.ok) {
       const message = getErrorMessage(res.status);


### PR DESCRIPTION
<!-- title: "[CAN-/커밋 컨벤션의 타입] 제목" -->
<!-- 예시 [CAN-123/feat] admin page 추가 / [CAN-123/refactor] 테스트 후 접근성 개선 -->

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

`해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`
- refresh로직 jwt callback함수로 이동했습니다.
- 배포환경에서 cookie접근과 변경에 오류가 발생하는 것 같아 jwt로 옮겼습니다.

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
  - 만료된 액세스 토큰을 자동으로 갱신하여 로그인 상태를 안정적으로 유지합니다.
  - 사용자 세션에 이름, 프로필 이미지 및 이메일 정보가 포함되어 보다 개인화된 경험을 제공합니다.
- **작업**
  - 내부 인증 로직을 정리하여 전체 시스템의 안정성과 성능이 향상되었습니다.
  - 불필요한 사용자 정보 가져오기 및 토큰 갱신 관련 기능이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->