### PR TITLE
[CAN-79/fix] 캘린더 페이지 테스트 오류 수정

### DIFF
--- a/src/components/common/input/DropDownInput.tsx
+++ b/src/components/common/input/DropDownInput.tsx
@@ -13,6 +13,9 @@ import { Goal } from '@/types/goals';
 const colorClasses: Record<string, string> = {
   goal01: 'bg-goal01',
   goal02: 'bg-goal02',
+  goal03: 'bg-goal03',
+  goal04: 'bg-goal04',
+  goal05: 'bg-goal05',
   default: 'bg-slate500',
 };
 

--- a/src/components/common/todo/CheckTodo.tsx
+++ b/src/components/common/todo/CheckTodo.tsx
@@ -15,6 +15,9 @@ import { Goal } from '@/types/goals';
 const goalColor: Record<string, string> = {
   goal01: 'text-goal01',
   goal02: 'text-goal02',
+  goal03: 'text-goal03',
+  goal04: 'text-goal04',
+  goal05: 'text-goal05',
   default: 'text-slate500',
 };
 
@@ -108,9 +111,9 @@ export default function CheckTodo({
         <IconButton
           className={cn(
             'flex-none rounded-2xl bg-gs00 text-slate500 group-hover:bg-gs00',
+            'opacity-100 md:opacity-0 md:group-hover:opacity-100',
             {
               'opacity-100': isMenuOpen,
-              'opacity-0 group-hover:opacity-100': !isMenuOpen,
             },
           )}
           icon={noteIcon}
@@ -122,10 +125,10 @@ export default function CheckTodo({
         <div className="relative">
           <IconButton
             className={cn(
-              'flex-none rounded-2xl bg-gs00 text-gs400 transition-opacity',
+              'flex-none rounded-2xl bg-gs00 text-slate500 group-hover:bg-gs00',
+              'opacity-100 md:opacity-0 md:group-hover:opacity-100',
               {
                 'opacity-100': isMenuOpen,
-                'opacity-0 group-hover:opacity-100': !isMenuOpen,
               },
             )}
             icon={faEllipsisVertical}

--- a/src/components/todoCalendar/CalendarBody.tsx
+++ b/src/components/todoCalendar/CalendarBody.tsx
@@ -13,6 +13,9 @@ import { useDeleteTodoBasket } from '@/hooks/useTodoBasket';
 const goalColor: Record<string, string> = {
   goal01: 'bg-goal01-100 text-goal01',
   goal02: 'bg-goal02-100 text-goal02',
+  goal03: 'bg-goal03-100 text-goal03',
+  goal04: 'bg-goal04-100 text-goal04',
+  goal05: 'bg-goal05-100 text-goal05',
   default: 'bg-slate100 text-slate500',
 };
 

--- a/src/components/todoCalendar/TodoBasket.tsx
+++ b/src/components/todoCalendar/TodoBasket.tsx
@@ -96,7 +96,7 @@ export default function TodoBasket() {
     ? createPortal(
         <div
           className={cn(
-            'fixed bottom-0 z-10 bg-white px-6 pb-2 pt-4 transition-all duration-300 ease-in-out',
+            'fixed bottom-0 z-10 bg-gs00 px-6 pb-2 pt-4 transition-all duration-300 ease-in-out',
             {
               'left-16 w-[calc(100vw-4rem)]': isFolded,
               'left-16 w-[calc(100vw-4rem)] md:left-64 md:w-[calc(100vw-16rem)] 2xl:left-80 2xl:w-[calc(100vw-20rem)]':

--- a/src/components/todoCalendar/TodoBasket.tsx
+++ b/src/components/todoCalendar/TodoBasket.tsx
@@ -123,13 +123,15 @@ export default function TodoBasket() {
                   </div>
                 )}
               </div>
-              <button
-                type="button"
-                className="text-14M text-gs600"
-                onClick={() => handleDeleteAll()}
-              >
-                모두 지우기
-              </button>
+              {basketList.length > 0 && (
+                <button
+                  type="button"
+                  className="text-14M text-gs600"
+                  onClick={() => handleDeleteAll()}
+                >
+                  모두 지우기
+                </button>
+              )}
             </div>
 
             <div

--- a/src/components/todoCalendar/TodoList.tsx
+++ b/src/components/todoCalendar/TodoList.tsx
@@ -52,9 +52,10 @@ export default function TodoList({ selectedDate, onOpenModal }: Props) {
           </h3>
           <div className="h-full">
             {isFetching && <SimpleTodoSkeleton repeat={3} />}
-            {!isFetching && incompleteTodos.length > 0 ? (
+            {!isFetching && incompleteTodos.length > 0 && (
               <TodoListItem todoList={incompleteTodos} />
-            ) : (
+            )}
+            {!isFetching && incompleteTodos.length === 0 && (
               <div className="flex h-full items-center justify-center text-center text-14M text-gs500">
                 등록된 할일이 없습니다.
               </div>
@@ -87,11 +88,12 @@ export default function TodoList({ selectedDate, onOpenModal }: Props) {
           {isCompletedOpen && (
             <div className="h-full overflow-y-auto">
               {isFetching && <SimpleTodoSkeleton repeat={3} />}
-              {!isFetching && completeTodos.length > 0 ? (
+              {!isFetching && completeTodos.length > 0 && (
                 <TodoListItem todoList={completeTodos} />
-              ) : (
+              )}
+              {!isFetching && completeTodos.length === 0 && (
                 <div className="flex h-full items-center justify-center text-center text-14M text-gs500">
-                  완료된 할일이 없습니다.
+                  등록된 할일이 없습니다.
                 </div>
               )}
             </div>

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -8,17 +8,15 @@
 }
 
 .fc-daygrid-day {
-  @apply bg-gs00;
+  @apply !border-[0.5px] !border-gs200 !bg-gs00;
   min-width: 30px;
   min-height: unset !important;
   max-width: 120px !important;
-  border: 0.5px solid #e2e8f0 !important;
   position: relative !important;
 }
 
 .fc-daygrid-day.selected {
-  outline: 2px solid #3b82f6 !important;
-  outline-offset: -2px;
+  @apply !outline !outline-2 !-outline-offset-2 !outline-slate500;
 }
 
 .fc-daygrid-day-top > a {
@@ -95,3 +93,10 @@
     padding-top: 4px !important;
   }
 } */
+
+.fc-theme-standard,
+.fc-theme-standard td,
+.fc-theme-standard th,
+.fc-theme-standard .fc-scrollgrid {
+  @apply !border-[0.5px] !border-gs200;
+}


### PR DESCRIPTION

## 개요 🔎
`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝
- 캘린더 페이지에서 변경된 목표 색상 적용
- 할일 리스트에서 loading skeleton과 할일없음이 동시에 뜨던 이슈 해결
- 장바구니 비어있으면 지우기 버튼 삭제
- 다크모드/테마 변경에서 캘린더 페이지에 적용되게 변경

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/7587b3c8-33f3-4306-b668-9ddff0b754b2" />
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/796bb1d0-473a-4390-8d51-1db910ac5a9f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 태스크 및 캘린더 관련 화면에 새로운 색상 옵션이 추가되어 시각적 표현이 강화되었습니다.
	- 할 일 삭제 버튼과 목록의 조건부 렌더링이 개선되어, 항목이 있을 때만 관련 인터페이스가 표시됩니다.
	- 드롭다운 입력에 새로운 색상 옵션이 추가되어 선택 항목의 스타일링이 향상되었습니다.

- **스타일**
	- 버튼의 투명도 및 반응성이 개선되어 다양한 화면 크기와 호버 상태에서 일관된 사용자 경험을 제공합니다.
	- 캘린더의 경계선과 선택된 날짜의 아웃라인 스타일이 업데이트되어 UI 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->