### PR TITLE
[CAN-72/fix] 로그인 성공 리디렉션 변경, dark 스타일 삭제, 한글 입력 막기 등

### DIFF
--- a/src/app/(guest)/(auth)/layout.tsx
+++ b/src/app/(guest)/(auth)/layout.tsx
@@ -13,7 +13,7 @@ export default function Layout({
           <IcanLogo className="size-12 flex-none" />
           <IcanTitle className="h-8 w-28" />
         </h2>
-        <p className="mb-10 break-keep text-gs700 dark:text-gs400">
+        <p className="mb-10 break-keep text-gs700">
           할 일을 계획하고 관리해요!
         </p>
       </div>

--- a/src/app/(guest)/(auth)/loading.tsx
+++ b/src/app/(guest)/(auth)/loading.tsx
@@ -3,7 +3,7 @@ export default function Loading() {
     <div className="flex min-h-96 w-full items-center justify-center">
       <div className="flex flex-col items-center space-y-4">
         <div className="size-12 animate-spin rounded-full border-4 border-gray-300 border-t-gray-900" />
-        <p className="text-gs00 dark:text-gray-400">로딩 중...</p>
+        <p className="text-gs00">로딩 중...</p>
       </div>
     </div>
   );

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -44,7 +44,7 @@ export default function LoginForm() {
       // 로그인 성공
       // toast.success('로그인 성공!');
       startTransition(() => {
-        router.push('/');
+        router.replace('/');
       });
       return;
     }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -6,16 +6,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
+import { useState } from 'react';
 import PasswordField from './PasswordField';
 import TextField from './TextField';
 import { LoginSchema, LoginSchemaType } from '@/lib/validation';
 import Button from '../common/button/Button';
 
-export interface Props {
-  email: string;
-  password: string;
-}
 export default function LoginForm() {
+  const [isLoading, setIsLoading] = useState(false);
   const {
     register,
     handleSubmit,
@@ -28,7 +26,10 @@ export default function LoginForm() {
   const router = useRouter();
 
   // 폼 제출 호출 함수
-  const onSubmit = async (data: Props) => {
+  const onSubmit = async (data: LoginSchemaType) => {
+    if (isLoading) return;
+    setIsLoading(true);
+
     const { email, password } = data;
     // Next-Auth 로그인
     const res = await signIn('credentials', {
@@ -39,7 +40,6 @@ export default function LoginForm() {
 
     if (!res?.error) {
       // 로그인 성공
-      // toast.success('로그인 성공!');
       router.replace('/');
       return;
     }
@@ -51,6 +51,8 @@ export default function LoginForm() {
         : '로그인에 실패했습니다. 잠시 후 다시 시도해주세요.';
 
     toast.error(errorMessage);
+
+    setIsLoading(false);
   };
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -71,7 +73,7 @@ export default function LoginForm() {
         />
         <div className="mb-8" />
         <Button
-          disabled={!isValid}
+          disabled={!isValid || isLoading}
           size="full"
           type="submit"
           variant="default"

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -6,7 +6,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { useTransition } from 'react';
 import PasswordField from './PasswordField';
 import TextField from './TextField';
 import { LoginSchema, LoginSchemaType } from '@/lib/validation';
@@ -17,8 +16,6 @@ export interface Props {
   password: string;
 }
 export default function LoginForm() {
-  const [isPending, startTransition] = useTransition(); // 비동기 작업 중 상태 처리
-
   const {
     register,
     handleSubmit,
@@ -43,9 +40,7 @@ export default function LoginForm() {
     if (!res?.error) {
       // 로그인 성공
       // toast.success('로그인 성공!');
-      startTransition(() => {
-        router.replace('/');
-      });
+      router.replace('/');
       return;
     }
 
@@ -80,9 +75,9 @@ export default function LoginForm() {
           size="full"
           type="submit"
           variant="default"
-          className="mb-12 h-12 transition-colors disabled:pointer-events-none disabled:bg-gs200 disabled:text-gs400 dark:disabled:bg-gs700 dark:disabled:text-gs400 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
+          className="mb-12 h-12 transition-colors disabled:pointer-events-none disabled:bg-gs200 disabled:text-gs400 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
         >
-          {isPending ? '로그인 중...' : '로그인하기'}
+          로그인하기
         </Button>
         <p className="text-center text-14M">
           I:can이 처음이신가요?

--- a/src/components/auth/PasswordField.tsx
+++ b/src/components/auth/PasswordField.tsx
@@ -30,6 +30,20 @@ export default function PasswordField<T extends FieldValues>({
   const handleTogglePasswordVisible = () => {
     setIsPasswordVisible(!isPasswordVisible);
   };
+  const [password, setPassword] = useState('');
+
+  // 비밀번호에 한글 입력 막기
+  const handleInputChange = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const inputElement = e.currentTarget;
+
+    // 숫자와 영문자, 허용 특수문자 외는 공백 처리
+    const filteredValue = inputElement.value.replace(
+      /[^A-Za-z0-9!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/g,
+      '',
+    );
+
+    setPassword(filteredValue);
+  };
 
   return (
     <div className="mb-6 w-full">
@@ -46,6 +60,8 @@ export default function PasswordField<T extends FieldValues>({
             placeholder={placeholder}
             autoComplete="off"
             {...register(name)}
+            value={password}
+            onInput={handleInputChange}
           />
           <button
             type="button"

--- a/src/components/auth/PasswordField.tsx
+++ b/src/components/auth/PasswordField.tsx
@@ -38,7 +38,7 @@ export default function PasswordField<T extends FieldValues>({
         <div className="relative w-full">
           <input
             className={cn(
-              'focus-visible:ring-ring h-12 w-full rounded-xl bg-slate50 px-4 py-3 text-16R transition-colors placeholder:text-gs400 focus:outline-none focus:ring-slate500 focus-visible:ring-1 dark:bg-gs800 dark:placeholder:text-gs500',
+              'focus-visible:ring-ring h-12 w-full rounded-xl bg-slate50 px-4 py-3 text-16R transition-colors placeholder:text-gs400 focus:outline-none focus:ring-slate500 focus-visible:ring-1',
               errors[name] && 'bg-warn50 focus-visible:ring-red-500',
             )}
             type={isPasswordVisible ? 'text' : 'password'}

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-// import { useState } from 'react';
 import { toast } from 'sonner';
 import { useState } from 'react';
 import TextField from './TextField';
@@ -33,6 +32,7 @@ export default function SignupForm() {
 
     if (success) {
       toast.success(message);
+      setIsLoading(false);
       router.push('/login');
       return;
     }

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -88,7 +88,7 @@ export default function SignupForm() {
           type="submit"
           size="full"
           variant="default"
-          className="mb-12 h-12 transition-colors disabled:pointer-events-none disabled:bg-gs200 disabled:text-gs400 dark:disabled:bg-gs700 dark:disabled:text-gs400 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
+          className="mb-12 h-12 transition-colors disabled:pointer-events-none disabled:bg-gs200 disabled:text-gs400 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
         >
           {isPending ? '회원가입 중...' : '회원가입하기'}
         </Button>

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -34,11 +34,12 @@ export default function SignupForm() {
     if (success) {
       toast.success(message);
       router.push('/login');
-    } else {
-      toast.error(
-        '회원가입에 실패했습니다. 사용하신 이메일이 이미 존재할 수 있습니다.',
-      );
+      return;
     }
+
+    toast.error(
+      '회원가입에 실패했습니다. 사용하신 이메일이 이미 존재할 수 있습니다.',
+    );
 
     setIsLoading(false);
   };

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -4,8 +4,9 @@ import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-import { useTransition } from 'react';
+// import { useState } from 'react';
 import { toast } from 'sonner';
+import { useState } from 'react';
 import TextField from './TextField';
 import PasswordField from './PasswordField';
 import { SignUpSchema, SignUpSchemaType } from '@/lib/validation';
@@ -21,23 +22,25 @@ export interface Props {
 
 export default function SignupForm() {
   const router = useRouter();
-  const [isPending, startTransition] = useTransition(); // 비동기 작업 중 상태 처리
+  const [isLoading, setIsLoading] = useState(false);
 
   // 회원가입 폼 제출 호출 함수
   const onSubmit = async (formData: Props) => {
+    if (isLoading) return;
+    setIsLoading(true);
+
     const { success, message } = await signup(formData);
 
-    // 회원가입 성공
     if (success) {
       toast.success(message);
-      startTransition(() => {
-        router.push('/login');
-      });
-      return;
+      router.push('/login');
+    } else {
+      toast.error(
+        '회원가입에 실패했습니다. 사용하신 이메일이 이미 존재할 수 있습니다.',
+      );
     }
-    // 회원가입 실패
-    toast.error(`회원가입에 실패했습니다. 
-  사용하신 이메일이 이미 존재할 수 있습니다. 이메일을 다시 확인해주세요.`);
+
+    setIsLoading(false);
   };
 
   // RHF 사용한 폼 상태 관리
@@ -84,13 +87,13 @@ export default function SignupForm() {
         <div className="mb-8" />
         {/* 회원가입 버튼 */}
         <Button
-          disabled={!isValid}
+          disabled={!isValid || isLoading}
           type="submit"
           size="full"
           variant="default"
           className="mb-12 h-12 transition-colors disabled:pointer-events-none disabled:bg-gs200 disabled:text-gs400 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
         >
-          {isPending ? '회원가입 중...' : '회원가입하기'}
+          회원가입하기
         </Button>
         <p className="text-center text-14M">
           이미 회원이신가요?

--- a/src/components/auth/TextField.tsx
+++ b/src/components/auth/TextField.tsx
@@ -32,7 +32,7 @@ export default function TextField<T extends FieldValues>({
         <span className="mb-4 text-16SB">{label}</span>
         <input
           className={cn(
-            'focus-visible:ring-ring h-12 w-full rounded-xl bg-slate50 px-4 py-3 text-16R transition-colors placeholder:text-gs400 focus:outline-none focus:ring-slate500 focus-visible:ring-1 dark:bg-gs800 dark:placeholder:text-gs500',
+            'focus-visible:ring-ring h-12 w-full rounded-xl bg-slate50 px-4 py-3 text-16R transition-colors placeholder:text-gs400 focus:outline-none focus:ring-slate500 focus-visible:ring-1',
             errors[name] && 'bg-warn50 focus-visible:ring-red-500',
           )}
           id={name} // label을 연결


### PR DESCRIPTION
## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝
* 로그인 성공 리디렉션 변경
* dark 스타일 삭제
* 비밀번호 입력 시 한글 입력 방지
* 로그인/회원가입 진행 시 버튼 비활성화 처리

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **스타일**
	- 인증 페이지의 텍스트 스타일이 업데이트되어, 어두운 테마 전용 스타일이 제거됨에 따라 모든 모드에서 일관된 디자인을 제공합니다.
- **폼 처리 개선**
	- 로그인 및 회원가입 과정에서 제출 상태 관리가 강화되어 중복 제출이 방지되며, 버튼 문구가 간소화되었습니다.
	- 비밀번호 입력 필드는 알파벳, 숫자 및 일부 특수문자 입력만 허용하도록 개선되어 보다 정확한 입력이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->