### PR TITLE
[CAN-74/fix] 테스트 기반 대시보드 수정

### DIFF
--- a/src/app/(member)/page.tsx
+++ b/src/app/(member)/page.tsx
@@ -8,31 +8,49 @@ import GoalList from '@/components/dashboard/goalList/GoalList';
 import TodoGrass from '@/components/dashboard/todoGrass/TodoGrass';
 import { getTodayProgress, getTodoGrass } from '@/services/dashboard';
 
-export default async function Page() {
+// 각 섹션을 별도의 컴포넌트로 분리
+async function TodaySection() {
   const { total, completed } = await getTodayProgress();
   const progress = Math.floor((completed / total) * 100) / 100 || 0;
-  const grassData = await getTodoGrass();
+  return (
+    <section className="flex flex-col gap-4 overflow-hidden md:flex-row md:gap-8">
+      <TodayList />
+      <ErrorBoundary errorComponent={TodayProgressError}>
+        <Suspense fallback={<TodayProgressSkeleton />}>
+          <TodayProgress progressData={progress} />
+        </Suspense>
+      </ErrorBoundary>
+    </section>
+  );
+}
 
+function GoalSection() {
+  return (
+    <section className="flex flex-col">
+      <p className="mb-3 text-16SB text-gsBk 2xl:text-18SB">목표별 할일</p>
+      <GoalList />
+    </section>
+  );
+}
+
+async function GrassSection() {
+  const grassData = await getTodoGrass();
+  return (
+    <section className="flex flex-col">
+      <div className="relative flex flex-col gap-4 rounded-2xl bg-gs00 px-6 py-4 2xl:gap-5 2xl:rounded-3xl">
+        <p className="text-16SB text-gsBk 2xl:text-18SB">올해 달성률</p>
+        <TodoGrass grassData={grassData} />
+      </div>
+    </section>
+  );
+}
+
+export default function Page() {
   return (
     <div className="flex flex-col gap-4">
-      <section className="flex flex-col gap-4 overflow-hidden md:flex-row md:gap-8">
-        <TodayList />
-        <ErrorBoundary errorComponent={TodayProgressError}>
-          <Suspense fallback={<TodayProgressSkeleton />}>
-            <TodayProgress progressData={progress} />
-          </Suspense>
-        </ErrorBoundary>
-      </section>
-      <section className="flex flex-col">
-        <p className="mb-3 text-16SB text-gsBk 2xl:text-18SB">목표별 할일</p>
-        <GoalList />
-      </section>
-      <section className="flex flex-col">
-        <div className="relative flex flex-col gap-4 rounded-2xl bg-gs00 px-6 py-4 2xl:gap-5 2xl:rounded-3xl">
-          <p className="text-16SB text-gsBk 2xl:text-18SB">올해 달성률</p>
-          <TodoGrass grassData={grassData} />
-        </div>
-      </section>
+      <TodaySection />
+      <GoalSection />
+      <GrassSection />
     </div>
   );
 }

--- a/src/app/api/todos/[todoId]/route.ts
+++ b/src/app/api/todos/[todoId]/route.ts
@@ -42,7 +42,10 @@ export async function PATCH(
 
   const res2Data = await res2.json();
 
-  return NextResponse.json({ ...res2Data, goal });
+  return NextResponse.json({
+    ...res2Data,
+    goal: { goalId: res2Data.goalId, ...goal },
+  });
 }
 
 export async function DELETE(

--- a/src/components/common/ClientProvider.tsx
+++ b/src/components/common/ClientProvider.tsx
@@ -5,7 +5,16 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactNode, useState } from 'react';
 
 export default function ClientProvider({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 5 * 60 * 1000,
+          },
+        },
+      }),
+  );
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/components/common/todo/SimpleTodo.tsx
+++ b/src/components/common/todo/SimpleTodo.tsx
@@ -1,19 +1,30 @@
 'use client';
 
 import { faFileLines, faFilePen } from '@fortawesome/free-solid-svg-icons';
+import { useRouter } from 'next/navigation';
 import cn from '@/utils/cn';
 import IconButton from '../button/IconButton';
 
 interface Props {
   title: string;
-  done: boolean;
+  done?: boolean;
+  todoId: number;
   noteId: number | null;
 }
 
-export default function SimpleTodo({ title, done, noteId }: Props) {
+export default function SimpleTodo({
+  title,
+  done = false,
+  todoId,
+  noteId,
+}: Props) {
   const noteIcon = noteId ? faFileLines : faFilePen;
+  const router = useRouter();
   /** 노트 클릭 함수 */
-  const clickNote = () => {};
+  const clickNote = () => {
+    if (!noteId) router.push(`/${todoId}/note/create`);
+    else router.push(`/note/${noteId}`);
+  };
   return (
     <div
       className={cn(

--- a/src/components/dashboard/goalList/GoalDoneSection.tsx
+++ b/src/components/dashboard/goalList/GoalDoneSection.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function GoalDoneSection({ isFetching, doneItems }: Props) {
   return (
-    <section className="flex flex-col gap-3 md:flex-[2]">
+    <section className="flex flex-col gap-3 md:w-2/5">
       <p className="text-14SB">완료</p>
       <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
         {isFetching && <SimpleTodoSkeleton />}

--- a/src/components/dashboard/goalList/GoalDoneSection.tsx
+++ b/src/components/dashboard/goalList/GoalDoneSection.tsx
@@ -1,0 +1,34 @@
+import SimpleTodo from '@/components/common/todo/SimpleTodo';
+import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
+import { Todo } from '@/types/todos';
+
+interface Props {
+  isFetching: boolean;
+  doneItems: Todo[];
+}
+
+export default function GoalDoneSection({ isFetching, doneItems }: Props) {
+  return (
+    <section className="flex flex-col gap-3 md:flex-[2]">
+      <p className="text-14SB">완료</p>
+      <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
+        {isFetching && <SimpleTodoSkeleton />}
+        {!isFetching &&
+          doneItems?.map((todo) => (
+            <SimpleTodo
+              key={todo.todoId}
+              title={todo.title}
+              todoId={todo.todoId}
+              noteId={todo.noteId}
+              done
+            />
+          ))}
+        {!isFetching && doneItems?.length === 0 && (
+          <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
+            완료된 할일이 없습니다.
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -33,7 +33,7 @@ export default function GoalList() {
         selectedIndex={selectedGoalIndex}
         onSelect={(index) => setSelectedGoalIndex(index)}
       />
-      <div className="flex w-full flex-col gap-6 rounded-b-lg bg-gs00 px-6 py-4 md:flex-row">
+      <div className="flex w-full flex-col gap-6 overflow-x-hidden rounded-b-lg bg-gs00 px-6 py-4 md:flex-row">
         <GoalTodoSection
           isFetching={isGoalsFetching || isTodoFetching}
           todoItems={todoItems}

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -44,7 +44,7 @@ export default function GoalList() {
                 <SimpleTodo
                   key={todo.todoId}
                   title={todo.title}
-                  done={false}
+                  todoId={todo.todoId}
                   noteId={todo.noteId}
                 />
               ))}
@@ -64,8 +64,9 @@ export default function GoalList() {
                 <SimpleTodo
                   key={todo.todoId}
                   title={todo.title}
-                  done
+                  todoId={todo.todoId}
                   noteId={todo.noteId}
+                  done
                 />
               ))}
             {!isTodoFetching && doneItems.length === 0 && (

--- a/src/components/dashboard/goalList/GoalList.tsx
+++ b/src/components/dashboard/goalList/GoalList.tsx
@@ -3,9 +3,9 @@
 import { useState } from 'react';
 import { useGoals } from '@/hooks/useGoals';
 import GoalTab from './GoalTab';
-import SimpleTodo from '@/components/common/todo/SimpleTodo';
-import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
 import { useGoalTodo } from '@/hooks/useGoalsTodo';
+import GoalDoneSection from './GoalDoneSection';
+import GoalTodoSection from './GoalTodoSection';
 
 export default function GoalList() {
   const [selectedGoalIndex, setSelectedGoalIndex] = useState<number>(0);
@@ -34,48 +34,14 @@ export default function GoalList() {
         onSelect={(index) => setSelectedGoalIndex(index)}
       />
       <div className="flex w-full flex-col gap-6 rounded-b-lg bg-gs00 px-6 py-4 md:flex-row">
-        <section className="flex flex-col gap-3 md:flex-[3]">
-          <p className="text-14SB">할일</p>
-          <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
-            {isGoalsFetching && <SimpleTodoSkeleton />}
-            {!isTodoFetching &&
-              /** TODO :: 목표 데이터 받아오는 fetch, data로 변경 */
-              todoItems.map((todo) => (
-                <SimpleTodo
-                  key={todo.todoId}
-                  title={todo.title}
-                  todoId={todo.todoId}
-                  noteId={todo.noteId}
-                />
-              ))}
-            {!isTodoFetching && todoItems.length === 0 && (
-              <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
-                등록된 할일이 없습니다.
-              </span>
-            )}
-          </div>
-        </section>
-        <section className="flex flex-col gap-3 md:flex-[2]">
-          <p className="text-14SB">완료</p>
-          <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
-            {isGoalsFetching && <SimpleTodoSkeleton />}
-            {!isTodoFetching &&
-              doneItems.map((todo) => (
-                <SimpleTodo
-                  key={todo.todoId}
-                  title={todo.title}
-                  todoId={todo.todoId}
-                  noteId={todo.noteId}
-                  done
-                />
-              ))}
-            {!isTodoFetching && doneItems.length === 0 && (
-              <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
-                완료된 할일이 없습니다.
-              </span>
-            )}
-          </div>
-        </section>
+        <GoalTodoSection
+          isFetching={isGoalsFetching || isTodoFetching}
+          todoItems={todoItems}
+        />
+        <GoalDoneSection
+          isFetching={isGoalsFetching || isTodoFetching}
+          doneItems={doneItems}
+        />
       </div>
     </>
   );

--- a/src/components/dashboard/goalList/GoalTodoSection.tsx
+++ b/src/components/dashboard/goalList/GoalTodoSection.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function GoalTodoSection({ isFetching, todoItems }: Props) {
   return (
-    <section className="flex flex-col gap-3 md:flex-[2]">
+    <section className="flex flex-col gap-3 md:w-3/5">
       <p className="text-14SB">할 일</p>
       <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
         {isFetching && <SimpleTodoSkeleton />}

--- a/src/components/dashboard/goalList/GoalTodoSection.tsx
+++ b/src/components/dashboard/goalList/GoalTodoSection.tsx
@@ -1,0 +1,33 @@
+import SimpleTodo from '@/components/common/todo/SimpleTodo';
+import SimpleTodoSkeleton from '@/components/common/todo/SimpleTodoSkeleton';
+import { Todo } from '@/types/todos';
+
+interface Props {
+  isFetching: boolean;
+  todoItems: Todo[];
+}
+
+export default function GoalTodoSection({ isFetching, todoItems }: Props) {
+  return (
+    <section className="flex flex-col gap-3 md:flex-[2]">
+      <p className="text-14SB">할 일</p>
+      <div className="w-full md:h-40 md:overflow-y-scroll 2xl:h-44">
+        {isFetching && <SimpleTodoSkeleton />}
+        {!isFetching &&
+          todoItems?.map((todo) => (
+            <SimpleTodo
+              key={todo.todoId}
+              title={todo.title}
+              todoId={todo.todoId}
+              noteId={todo.noteId}
+            />
+          ))}
+        {!isFetching && todoItems?.length === 0 && (
+          <span className="relative block w-full text-center text-14M text-gs400 md:top-[70px] 2xl:top-[78px]">
+            등록된 할일이 없습니다.
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/todayList/TodayList.tsx
+++ b/src/components/dashboard/todayList/TodayList.tsx
@@ -14,7 +14,7 @@ export default function TodayList() {
   const { data: totalList, isFetching } = useDailyTodos(
     new Date().toLocaleDateString('sv-SE'),
   );
-  const todayList = totalList.filter((todo) => !todo.done);
+  const todayList = totalList?.filter((todo) => !todo.done);
   const formatter = new Intl.DateTimeFormat('ko-KR', { dateStyle: 'long' });
   const formattedDate = formatter.format(new Date());
 
@@ -47,7 +47,7 @@ export default function TodayList() {
       <div className="flex h-40 w-full flex-col overflow-y-auto 2xl:h-44">
         {isFetching && <SimpleTodoSkeleton />}
         {!isFetching &&
-          todayList.map((todo) => (
+          todayList?.map((todo) => (
             <SimpleTodo
               key={todo.todoId}
               title={todo.title}
@@ -55,7 +55,7 @@ export default function TodayList() {
               noteId={todo.noteId}
             />
           ))}
-        {!isFetching && !todayList.length && <TodayListEmpty />}
+        {!isFetching && !todayList?.length && <TodayListEmpty />}
       </div>
     </div>
   );

--- a/src/components/dashboard/todayList/TodayList.tsx
+++ b/src/components/dashboard/todayList/TodayList.tsx
@@ -51,7 +51,7 @@ export default function TodayList() {
             <SimpleTodo
               key={todo.todoId}
               title={todo.title}
-              done={false}
+              todoId={todo.todoId}
               noteId={todo.noteId}
             />
           ))}

--- a/src/components/dashboard/todayProgress/TodayProgress.tsx
+++ b/src/components/dashboard/todayProgress/TodayProgress.tsx
@@ -14,7 +14,7 @@ export default function TodayProgress({ progressData }: Props) {
   const progress = data || progressData;
   /**
    * @returns 진행도에 따른 문구
-   * prgress에 맞는 문구를 리턴해주는 함수
+   * progress에 맞는 문구를 리턴해주는 함수
    */
   const getProgressMessage = () => {
     if (progress <= 0.1) return '차근차근 시작해볼까요?';

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -26,5 +26,7 @@ export const useGrass = (initialData: Grass[]) => {
     queryKey: [QUERY_KEY.GRASS],
     queryFn: fetchTodoGrass,
     initialData,
+    retry: 3,
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -134,9 +134,9 @@ export const useUpdateTodo = () => {
         queryKey: [QUERY_KEY.GRASS],
       });
 
-      if (goal?.id) {
+      if (goal?.goalId) {
         queryClient.invalidateQueries({
-          queryKey: [QUERY_KEY.GOAL_TODOS, goal?.id],
+          queryKey: [QUERY_KEY.GOAL_TODOS, goal?.goalId],
         });
       }
 

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -46,7 +46,7 @@ export const useAddTodo = () => {
   return useMutation({
     mutationFn: (formData: TodoFormValues) => addTodo(formData),
     onSuccess: (newTodo) => {
-      const { date } = newTodo;
+      const { date, goal } = newTodo;
       const year = new Date(date).getFullYear();
       const month = new Date(date).getMonth() + 1;
 
@@ -61,6 +61,13 @@ export const useAddTodo = () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.MONTHLY_TODOS, { year, month }],
       });
+
+      if (goal?.goalId) {
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY.GOAL_TODOS, goal?.goalId],
+        });
+      }
+
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.GRASS],
       });
@@ -126,6 +133,12 @@ export const useUpdateTodo = () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.GRASS],
       });
+
+      if (goal?.id) {
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY.GOAL_TODOS, goal?.id],
+        });
+      }
 
       // 노트에 변경 사항 반영
       if (noteId) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -169,7 +169,7 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--gs300);
   border-radius: 4px;
 }
 


### PR DESCRIPTION
<!-- title: "[CAN-/커밋 컨벤션의 타입] 제목" -->
<!-- 예시 [CAN-123/feat] admin page 추가 / [CAN-123/refactor] 테스트 후 접근성 개선 -->

## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

`해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`

- 대시보드 노트 이동 추가
- queryClient default StaleTime 설정
- 대시보드 목표별 할일 할일/완료 가로길이 오버되는 문제 수정
- data가 undefined일 경우를 고려하여 optional chaining 사용
- scroll색상 수정 gs300
## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 대시보드에 진행 중인 목표와 완료된 목표를 명확하게 구분하여 표시하는 새로운 섹션 추가
	- 할 일 항목의 노트 생성 및 업데이트를 위한 개선된 네비게이션 기능 적용
	- 오늘의 진행 상황을 표시하는 새로운 섹션 추가
	- 완료된 목표를 표시하는 새로운 섹션 추가

- **Refactor**
	- 페이지 구성이 “오늘”, “목표”, “성과” 섹션으로 모듈화되어 구조와 데이터 처리 로직이 최적화됨
	- 데이터 캐싱 및 오류 처리 로직이 강화되어 더욱 안정적인 사용자 경험 제공

- **Style**
	- 스크롤바 디자인이 테마 변수 기반으로 업데이트되어 일관된 시각 효과 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->