### PR TITLE
[CAN-82/fix] 캘린더&노트 페이지 이슈 해결

### DIFF
--- a/src/app/(member)/goals/[id]/page.tsx
+++ b/src/app/(member)/goals/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { config } from '@fortawesome/fontawesome-svg-core';
 import { useState } from 'react';
-import { faFaceSadCry, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { faFaceSadCry } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import GoalBasket from '@/components/goalDetail/GoalBasket';
 import GoalDoneList from '@/components/goalDetail/GoalDoneList';
@@ -13,6 +13,7 @@ import '@fortawesome/fontawesome-svg-core/styles.css';
 import { useGoalTodo, useToggleTodo } from '@/hooks/useGoalsTodo';
 import goalColors from '@/presets/goalColors';
 import colors from '@/presets/colors';
+import Loading from '@/components/common/Loading';
 
 config.autoAddCss = false;
 
@@ -40,16 +41,7 @@ export default function Page({ params }: { params: { id: string } }) {
   };
 
   // 로딩 화면 렌더링 함수
-  const renderLoading = () => (
-    <div className="flex min-h-dvh items-center justify-center">
-      <FontAwesomeIcon
-        icon={faSpinner}
-        spin
-        className="text-4xl text-slate500"
-      />
-      <span className="ml-2 text-lg text-slate400">로딩 중...</span>
-    </div>
-  );
+  const renderLoading = () => <Loading />;
 
   // 목표가 없을 때 화면 렌더링 함수
   const renderNoGoal = () => (

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -1,11 +1,15 @@
-/**
- * 임시 로딩 컴포넌트
- * 추후 common으로 이동
- */
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 export default function Loading() {
   return (
-    <div className="flex items-center justify-center">
-      <p className="text-gray-500">로딩 중...</p>
+    <div className="flex min-h-dvh items-center justify-center">
+      <FontAwesomeIcon
+        icon={faSpinner}
+        spin
+        className="size-10 text-slate500"
+      />
+      <span className="ml-2 text-lg text-slate400">로딩 중...</span>
     </div>
   );
 }

--- a/src/components/common/todo/CheckTodo.tsx
+++ b/src/components/common/todo/CheckTodo.tsx
@@ -154,7 +154,7 @@ export default function CheckTodo({
               </button>
               <button
                 type="button"
-                className="flex whitespace-nowrap px-4 py-2 text-14R text-gs700 hover:bg-gs200"
+                className="flex whitespace-nowrap px-4 py-2 text-14R text-gsBk hover:bg-gs200"
                 onClick={() => {
                   if (onDelete) onDelete();
                 }}

--- a/src/components/note/noteDetail/NoteDetail.tsx
+++ b/src/components/note/noteDetail/NoteDetail.tsx
@@ -186,14 +186,14 @@ export default function NoteDetail({
                   >
                     <button
                       type="button"
-                      className="flex whitespace-nowrap rounded px-4 py-2 text-14R text-gs700 hover:bg-gs200"
+                      className="flex whitespace-nowrap rounded px-4 py-2 text-14R text-gsBk hover:bg-gs200"
                       onClick={handleEdit}
                     >
                       수정하기
                     </button>
                     <button
                       type="button"
-                      className="flex whitespace-nowrap rounded px-4 py-2 text-14R text-gs700 hover:bg-gs200"
+                      className="flex whitespace-nowrap rounded px-4 py-2 text-14R text-gsBk hover:bg-gs200"
                       onClick={handleDeleteButton}
                     >
                       삭제하기

--- a/src/components/note/noteDetail/NoteDetail.tsx
+++ b/src/components/note/noteDetail/NoteDetail.tsx
@@ -159,7 +159,7 @@ export default function NoteDetail({
               {/* 목표 제목 */}
               <div className="flex items-center justify-between">
                 {note.todo.goal && (
-                  <h1 className="flex items-center gap-3 text-16M">
+                  <h1 className="flex items-center gap-3 text-16M text-gsBk">
                     <Icon
                       icon={faFlag}
                       className={cn(
@@ -214,7 +214,9 @@ export default function NoteDetail({
           <div className="flex flex-col gap-4">
             {/* 노트 제목 */}
             <div className="flex items-center justify-between border-y py-3">
-              <h1 className="flex items-center text-18M">{note.title}</h1>
+              <h1 className="flex items-center text-18M text-gsBk">
+                {note.title}
+              </h1>
             </div>
             {note.linkUrl && (
               <button
@@ -236,7 +238,7 @@ export default function NoteDetail({
 
             {/* 내용 */}
             <div
-              className="whitespace-pre-line text-16R text-gs700"
+              className="whitespace-pre-line text-16R text-gsBk"
               dangerouslySetInnerHTML={{ __html: sanitizedContent || '' }}
             />
           </div>

--- a/src/components/note/noteDetail/NoteDetail.tsx
+++ b/src/components/note/noteDetail/NoteDetail.tsx
@@ -204,7 +204,7 @@ export default function NoteDetail({
             </div>
 
             {/* To do */}
-            <div className="flex items-center gap-2 text-gs700">
+            <div className="flex items-center gap-2 text-gs600">
               <span className="rounded bg-gs200 p-1 text-12M">To do</span>
               <span className="text-14R">{note.todo.title}</span>
               <span className="ml-auto text-12R">{note.updatedAt}</span>

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -23,7 +23,7 @@ export default function TodoCalendar() {
 
   // 한 달 단위 할 일
   const {
-    data: monthlyTodos,
+    data: monthlyTodos = [],
     isLoading,
     error,
   } = useMonthlyTodos(currentYear, currentMonth);
@@ -55,7 +55,7 @@ export default function TodoCalendar() {
     }
 
     return undefined;
-  }, []);
+  }, [monthlyTodos]);
 
   return error ? (
     <div>
@@ -80,7 +80,6 @@ export default function TodoCalendar() {
               }}
             />
           )}
-          {!isCalendarLoaded && <Loading />}
         </div>
         {isCalendarLoaded && (
           <div

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -26,6 +26,8 @@ export default function TodoCalendar() {
     data: monthlyTodos = [],
     isLoading,
     error,
+    refetch,
+    hasFetched,
   } = useMonthlyTodos(currentYear, currentMonth);
 
   const handleOpenModal = () => setIsModalOpen(true);
@@ -55,7 +57,13 @@ export default function TodoCalendar() {
     }
 
     return undefined;
-  }, [monthlyTodos]);
+  }, []);
+
+  useEffect(() => {
+    if (!isLoading && !hasFetched && monthlyTodos.length === 0) {
+      refetch();
+    }
+  }, [isLoading, monthlyTodos, hasFetched, refetch]);
 
   return error ? (
     <div>

--- a/src/components/todoCalendar/TodoCalendar.tsx
+++ b/src/components/todoCalendar/TodoCalendar.tsx
@@ -26,8 +26,6 @@ export default function TodoCalendar() {
     data: monthlyTodos = [],
     isLoading,
     error,
-    refetch,
-    hasFetched,
   } = useMonthlyTodos(currentYear, currentMonth);
 
   const handleOpenModal = () => setIsModalOpen(true);
@@ -58,12 +56,6 @@ export default function TodoCalendar() {
 
     return undefined;
   }, []);
-
-  useEffect(() => {
-    if (!isLoading && !hasFetched && monthlyTodos.length === 0) {
-      refetch();
-    }
-  }, [isLoading, monthlyTodos, hasFetched, refetch]);
 
   return error ? (
     <div>

--- a/src/components/todoCalendar/TodoList.tsx
+++ b/src/components/todoCalendar/TodoList.tsx
@@ -20,7 +20,7 @@ interface Props {
  */
 export default function TodoList({ selectedDate, onOpenModal }: Props) {
   // 하루 단위 할 일
-  const { data: todos, isFetching } = useDailyTodos(
+  const { data: todos = [], isFetching } = useDailyTodos(
     selectedDate.toLocaleDateString('sv-SE'),
   );
 

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -34,7 +34,6 @@ export const useDailyTodos = (date: string) => {
     queryKey: [QUERY_KEY.DAILY_TODOS, date],
     queryFn: () => fetchDailyTodos(date),
     retry: false,
-    initialData: [],
     throwOnError: false,
   });
 };

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
 import { getErrorMessage } from '@/constants/errorMessages';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { Todo } from '@/types/todos';
@@ -22,21 +21,13 @@ const fetchDailyTodos = async (date: string) => {
 };
 
 export const useMonthlyTodos = (year: number, month: number) => {
-  const [hasFetched, setHasFetched] = useState(false);
-  const query = useQuery<Todo[]>({
+  return useQuery<Todo[]>({
     queryKey: [QUERY_KEY.MONTHLY_TODOS, { year, month }],
-    queryFn: async () => {
-      const data = await fetchMonthlyTodos(year, month);
-      setHasFetched(true);
-      return data;
-    },
+    queryFn: () => fetchMonthlyTodos(year, month),
     initialData: [],
+    staleTime: 0,
     retry: false,
   });
-  return {
-    ...query,
-    hasFetched,
-  };
 };
 
 export const useDailyTodos = (date: string) => {
@@ -54,7 +45,7 @@ export const useAddTodo = () => {
   return useMutation({
     mutationFn: (formData: TodoFormValues) => addTodo(formData),
     onSuccess: (newTodo) => {
-      const { date, goal } = newTodo;
+      const { date } = newTodo;
       const year = new Date(date).getFullYear();
       const month = new Date(date).getMonth() + 1;
 
@@ -69,13 +60,6 @@ export const useAddTodo = () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.MONTHLY_TODOS, { year, month }],
       });
-
-      if (goal?.goalId) {
-        queryClient.invalidateQueries({
-          queryKey: [QUERY_KEY.GOAL_TODOS, goal?.goalId],
-        });
-      }
-
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.GRASS],
       });
@@ -141,12 +125,6 @@ export const useUpdateTodo = () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.GRASS],
       });
-
-      if (goal?.goalId) {
-        queryClient.invalidateQueries({
-          queryKey: [QUERY_KEY.GOAL_TODOS, goal?.goalId],
-        });
-      }
 
       // 노트에 변경 사항 반영
       if (noteId) {

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 import { getErrorMessage } from '@/constants/errorMessages';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { Todo } from '@/types/todos';
@@ -21,12 +22,21 @@ const fetchDailyTodos = async (date: string) => {
 };
 
 export const useMonthlyTodos = (year: number, month: number) => {
-  return useQuery<Todo[]>({
+  const [hasFetched, setHasFetched] = useState(false);
+  const query = useQuery<Todo[]>({
     queryKey: [QUERY_KEY.MONTHLY_TODOS, { year, month }],
-    queryFn: () => fetchMonthlyTodos(year, month),
+    queryFn: async () => {
+      const data = await fetchMonthlyTodos(year, month);
+      setHasFetched(true);
+      return data;
+    },
+    initialData: [],
     retry: false,
-    throwOnError: false,
   });
+  return {
+    ...query,
+    hasFetched,
+  };
 };
 
 export const useDailyTodos = (date: string) => {

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -24,7 +24,6 @@ export const useMonthlyTodos = (year: number, month: number) => {
   return useQuery<Todo[]>({
     queryKey: [QUERY_KEY.MONTHLY_TODOS, { year, month }],
     queryFn: () => fetchMonthlyTodos(year, month),
-    initialData: [],
     retry: false,
     throwOnError: false,
   });
@@ -34,7 +33,6 @@ export const useDailyTodos = (date: string) => {
   return useQuery<Todo[]>({
     queryKey: [QUERY_KEY.DAILY_TODOS, date],
     queryFn: () => fetchDailyTodos(date),
-    initialData: [],
     retry: false,
     throwOnError: false,
   });

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -34,6 +34,7 @@ export const useDailyTodos = (date: string) => {
     queryKey: [QUERY_KEY.DAILY_TODOS, date],
     queryFn: () => fetchDailyTodos(date),
     retry: false,
+    initialData: [],
     throwOnError: false,
   });
 };

--- a/src/styles/datePicker.css
+++ b/src/styles/datePicker.css
@@ -11,8 +11,12 @@
   @apply !rounded-t-2xl !border-2 !border-gs200 !bg-gs50 !p-2;
 }
 
+.react-datepicker__month {
+  @apply !bg-gs00;
+}
+
 .react-datepicker__day {
-  @apply !w-9 !rounded-lg py-1 !text-14M hover:!bg-gs200 2xl:!text-16M;
+  @apply !w-9 !rounded-lg py-1 !text-14M !text-gsBk hover:!bg-gs200 2xl:!text-16M;
   line-height: 1.25rem !important;
 }
 


### PR DESCRIPTION
## 작업내용 📝
- 노트에서 글자색 적용 안된 부분 변경
- useQuery에서 initialData 삭제
- 대시보드에서 initialData를 삭제해서 생긴 문제는 민지님 pr 합치고 난 이후 정상 작동될 예정 (http://localhost:3000/todoCalendar 로 바로 접속하시면 됩니다)
- 캘린더 페이지 loading spinner 추가
- date picker 다크모드에 맞게 디자인되도록 수정

### ‼️변경
montly todo는 stale time 0으로 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - 로딩 스피너 구현을 전용 로딩 컴포넌트로 대체하여 일관된 피드백을 제공합니다.
  - 캘린더 및 투두 리스트 데이터 초기화 로직을 개선해 안정적인 동작을 유도합니다.

- **Style**
  - 체크 투두와 노트 상세 화면의 버튼, 제목 및 텍스트 색상을 업데이트해 시각적 일관성을 강화했습니다.
  - 데이트 피커의 배경 및 텍스트 스타일을 조정해 사용자 인터페이스 외관이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->