### PR TITLE
[CAN-81/fix] 다크 모드에 맞는 목표 색상 & 노트 목록 페이지 수정

### DIFF
--- a/src/app/(member)/goals/[id]/page.tsx
+++ b/src/app/(member)/goals/[id]/page.tsx
@@ -17,12 +17,11 @@ import colors from '@/presets/colors';
 config.autoAddCss = false;
 
 const getGoalColor = (color: string) => {
-  return (
-    goalColors[color as keyof typeof goalColors] ?? {
-      100: colors.slate100,
-      DEFAULT: colors.slate500,
-    }
-  );
+  return {
+    100:
+      goalColors[`${color}-100` as keyof typeof goalColors] ?? colors.slate100,
+    DEFAULT: goalColors[color as keyof typeof goalColors] ?? colors.slate500,
+  };
 };
 
 export default function Page({ params }: { params: { id: string } }) {

--- a/src/components/goalDetail/GoalBasket.tsx
+++ b/src/components/goalDetail/GoalBasket.tsx
@@ -128,6 +128,7 @@ export default function GoalBasket({ basketItems, goalId, color }: Props) {
                       }
                       onCalendarOpen={() => handleCalendarOpen(item.id)}
                       onCalendarClose={handleCalendarClose}
+                      calendarClassName="bg-gs00 text-gsBk"
                       popperClassName="z-[9999]"
                       renderCustomHeader={({
                         date,
@@ -146,7 +147,7 @@ export default function GoalBasket({ basketItems, goalId, color }: Props) {
                           d.toDateString() === today.toDateString();
                         const isSunday = getDay(d) === 0;
 
-                        let className = '';
+                        let className = 'text-gsBk ';
 
                         if (isToday)
                           className +=

--- a/src/components/goalDetail/GoalBasket.tsx
+++ b/src/components/goalDetail/GoalBasket.tsx
@@ -6,6 +6,7 @@ import {
   faCircleQuestion,
 } from '@fortawesome/free-solid-svg-icons';
 import DatePicker from 'react-datepicker';
+import { getDay } from 'date-fns';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Basket } from '@/types/todos';
 import BasketTodoModal from './BasketTodoModal';
@@ -13,6 +14,7 @@ import { useGoalAddTodo } from '@/hooks/useGoalsTodo';
 import { useDeleteBasketTodo } from '@/hooks/useGoalBasketTodo';
 import ConfirmModal from '@/components/common/ConfirmModal';
 import IconButton from '../common/button/IconButton';
+import CustomDateHeader from '../common/input/datePicker/CustomDateHeader';
 
 interface Props {
   basketItems: Basket[];
@@ -104,7 +106,7 @@ export default function GoalBasket({ basketItems, goalId, color }: Props) {
             basketItems.map((item) => (
               <li
                 key={item.id}
-                className={`flex items-center justify-between border-b border-dashed border-gs300 pb-2 text-gs700 transition-colors ${
+                className={`flex items-center justify-between border-b border-dashed border-gs300 pb-2 text-gsBk transition-colors ${
                   hoveredItem === item.id || openDatePickerItemId === item.id
                     ? 'text-slate500'
                     : 'text-gs700'
@@ -127,13 +129,31 @@ export default function GoalBasket({ basketItems, goalId, color }: Props) {
                       onCalendarOpen={() => handleCalendarOpen(item.id)}
                       onCalendarClose={handleCalendarClose}
                       popperClassName="z-[9999]"
+                      renderCustomHeader={({
+                        date,
+                        decreaseMonth,
+                        increaseMonth,
+                      }) => (
+                        <CustomDateHeader
+                          date={date}
+                          decreaseMonth={decreaseMonth}
+                          increaseMonth={increaseMonth}
+                        />
+                      )}
                       dayClassName={(d) => {
                         const today = new Date();
                         const isToday =
                           d.toDateString() === today.toDateString();
-                        return isToday
-                          ? 'selected-day react-datepicker__day--today'
-                          : '';
+                        const isSunday = getDay(d) === 0;
+
+                        let className = '';
+
+                        if (isToday)
+                          className +=
+                            'selected-day react-datepicker__day--today ';
+                        if (isSunday) className += 'text-warn500';
+
+                        return className.trim();
                       }}
                       customInput={
                         <button

--- a/src/components/goalDetail/GoalBasket.tsx
+++ b/src/components/goalDetail/GoalBasket.tsx
@@ -128,7 +128,7 @@ export default function GoalBasket({ basketItems, goalId, color }: Props) {
                       }
                       onCalendarOpen={() => handleCalendarOpen(item.id)}
                       onCalendarClose={handleCalendarClose}
-                      calendarClassName="bg-gs00 text-gsBk"
+                      calendarClassName="bg-gs00"
                       popperClassName="z-[9999]"
                       renderCustomHeader={({
                         date,

--- a/src/components/goalDetail/GoalHeader.tsx
+++ b/src/components/goalDetail/GoalHeader.tsx
@@ -20,7 +20,9 @@ interface Props {
   setGoalAvailable: (value: boolean) => void;
 }
 
-const colorKeys = Object.keys(goalColors) as (keyof typeof goalColors)[];
+const colorKeys = (
+  Object.keys(goalColors) as (keyof typeof goalColors)[]
+).filter((key) => !key.includes('-100'));
 
 export default function GoalHeader({ id, setGoalAvailable }: Props) {
   const { data: goals, isLoading } = useGoals();
@@ -126,7 +128,7 @@ export default function GoalHeader({ id, setGoalAvailable }: Props) {
   const defaultColorStyle: React.CSSProperties = useMemo(() => {
     const goalColor = goalColors[goalItem?.color as keyof typeof goalColors];
     const validColor =
-      goalColor?.DEFAULT ??
+      goalColor ??
       colors[goalItem?.color as keyof typeof colors] ??
       colors.slate500;
 
@@ -134,13 +136,15 @@ export default function GoalHeader({ id, setGoalAvailable }: Props) {
   }, [goalItem?.color]);
 
   const colorStyle: React.CSSProperties = useMemo(() => {
-    const goalColor = goalColors[goalItem?.color as keyof typeof goalColors];
+    const goalColor100 =
+      goalColors[`${goalItem?.color}-100` as keyof typeof goalColors];
+
     const validColor =
-      goalColor?.['100'] ??
+      goalColor100 ??
       colors[goalItem?.color as keyof typeof colors] ??
       colors.slate100;
 
-    return { backgroundColor: validColor as string };
+    return { backgroundColor: validColor };
   }, [goalItem?.color]);
 
   return (
@@ -202,7 +206,9 @@ export default function GoalHeader({ id, setGoalAvailable }: Props) {
                     onClick={() => handleColorSelect(key)}
                     aria-label={`색상 변경: ${key}`}
                     className="size-6 rounded-full border border-transparent transition-transform duration-200 ease-in-out hover:scale-110 active:scale-90"
-                    style={{ backgroundColor: goalColors[key].DEFAULT }}
+                    style={{
+                      backgroundColor: goalColors[key] || colors.slate500,
+                    }}
                   />
                 </div>
               ))}
@@ -249,7 +255,8 @@ export default function GoalHeader({ id, setGoalAvailable }: Props) {
           <button
             type="button"
             onClick={toggleMobileMenu}
-            className="relative flex items-center justify-center rounded-full bg-slate100 p-1 shadow"
+            className="relative flex items-center justify-center rounded-full p-1 shadow"
+            style={colorStyle}
           >
             <span className="flex size-8 items-center justify-center rounded-full">
               <FontAwesomeIcon icon={faEllipsisVertical} />
@@ -269,7 +276,7 @@ export default function GoalHeader({ id, setGoalAvailable }: Props) {
                 onClick={handleDeleteClick}
                 className="block w-full px-4 py-2 text-12M text-warn500 hover:bg-slate100"
               >
-                삭제하기
+                목표 삭제
               </button>
             </div>
           )}

--- a/src/components/goalDetail/GoalHeader.tsx
+++ b/src/components/goalDetail/GoalHeader.tsx
@@ -267,7 +267,7 @@ export default function GoalHeader({ id, setGoalAvailable }: Props) {
               <button
                 type="button"
                 onClick={handleEditClick}
-                className="block w-full px-4 py-2 text-12M text-slate800 hover:bg-slate100"
+                className="block w-full px-4 py-2 text-12M text-gsBk hover:bg-slate100"
               >
                 목표 수정
               </button>

--- a/src/components/note/NoteItem.tsx
+++ b/src/components/note/NoteItem.tsx
@@ -14,18 +14,18 @@ interface NoteItemProps {
 
 export default function NoteItem({ note }: NoteItemProps) {
   return (
-    <div className="mb-4 rounded-xl border bg-gs00 p-6 shadow-md sm:max-h-[200px] md:max-h-[200px] lg:max-h-[120px]">
+    <div className="mb-4 rounded-xl bg-gs00 p-6 text-gs600 shadow-md sm:max-h-[200px] md:max-h-[200px] lg:max-h-[120px]">
       {/* 제목 */}
       <Link
         href={`/note/${note.id}`}
-        className="block w-full cursor-pointer border-b pb-3 text-left text-18M font-semibold hover:text-slate500"
+        className="block w-full cursor-pointer border-b border-gs200 pb-3 text-left text-18M font-semibold hover:text-slate500"
       >
         {note.title}
       </Link>
 
       {/* todo */}
-      <div className="mt-3 flex items-center gap-2 text-gs700">
-        <span className="mr-2 rounded-[4px] bg-gs200 p-1 text-12SB">To do</span>
+      <div className="mt-3 flex items-center gap-2 text-gs600">
+        <span className="mr-2 rounded-[4px] bg-gs100 p-1 text-12SB">To do</span>
         <span className="mr-2 text-12R">{note.todo.title}</span>
       </div>
     </div>

--- a/src/presets/goalColors.ts
+++ b/src/presets/goalColors.ts
@@ -1,15 +1,24 @@
 import colors from '@/presets/colors';
 
 const goalColors: Record<
-  `goal0${1 | 2 | 3 | 4 | 5}` | 'default',
-  { 100: string; DEFAULT: string }
+  | `goal0${1 | 2 | 3 | 4 | 5}`
+  | `goal0${1 | 2 | 3 | 4 | 5}-100`
+  | 'default'
+  | 'default-100',
+  string
 > = {
-  default: { 100: colors.slate100, DEFAULT: colors.slate500 },
-  goal01: { 100: '#FFEEE0', DEFAULT: '#FB923C' },
-  goal02: { 100: '#FFF9E1', DEFAULT: '#FACC15' },
-  goal03: { 100: '#EFFFFC', DEFAULT: '#1EEABE' },
-  goal04: { 100: '#FCF3FE', DEFAULT: '#C95AEE' },
-  goal05: { 100: '#FFECEC', DEFAULT: '#F87171' },
+  'default-100': colors.slate100,
+  default: colors.slate500,
+  'goal01-100': colors.goal01['100'],
+  goal01: colors.goal01.DEFAULT,
+  'goal02-100': colors.goal02['100'],
+  goal02: colors.goal02.DEFAULT,
+  'goal03-100': colors.goal03['100'],
+  goal03: colors.goal03.DEFAULT,
+  'goal04-100': colors.goal04['100'],
+  goal04: colors.goal04.DEFAULT,
+  'goal05-100': colors.goal05['100'],
+  goal05: colors.goal05.DEFAULT,
 };
 
 export default goalColors;


### PR DESCRIPTION
## 개요 🔎

`어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요.`

## 작업내용 📝

-목표 색상 100 수정
-노트 목록 페이지 디자인에 맞게 수정
-할일 장바구니 캘린더 수정

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`

![스크린샷 2025-03-17 132609](https://github.com/user-attachments/assets/6dd90587-167d-465d-923f-332708e415df)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- 목표 색상 표기를 개선하여 UI의 색상 일관성이 강화되었습니다.
	- 캘린더 뷰에서 오늘과 일요일을 강조하여 날짜 인식이 더욱 용이해졌습니다.
	- 목표 헤더의 삭제 버튼 문구가 "목표 삭제"로 변경되어 액션이 명확해졌습니다.
	- 노트 항목의 레이아웃과 색상 스타일이 업데이트되어 가독성과 디자인이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->