### PR TITLE
[CAN-83] fix: 다크모드일 때 텍스트 색 수정, default 목표일 때 색상 가져옴 수정

### DIFF
--- a/src/app/(guest)/(auth)/layout.tsx
+++ b/src/app/(guest)/(auth)/layout.tsx
@@ -13,7 +13,7 @@ export default function Layout({
           <IcanLogo className="size-12 flex-none" />
           <IcanTitle className="h-8 w-28" />
         </h2>
-        <p className="mb-10 break-keep text-gs700">
+        <p className="mb-10 break-keep text-gs600">
           할 일을 계획하고 관리해요!
         </p>
       </div>

--- a/src/components/note/noteCreate/EmbedPreview.tsx
+++ b/src/components/note/noteCreate/EmbedPreview.tsx
@@ -78,7 +78,7 @@ export default function EmbedPreview({
       <button type="button" onClick={onClose}>
         <Icon
           icon={faClose}
-          className="absolute right-4 top-4 rounded-full bg-gs600 text-gs00 transition-colors hover:bg-gs700 focus:bg-gs700 active:bg-gs700"
+          className="hover:bg-gsbk focus:bg-gsbk active:bg-gsbk absolute right-4 top-4 rounded-full bg-gs600 text-gs00 transition-colors"
         />
       </button>
     </section>

--- a/src/components/note/noteCreate/EmbedPreview.tsx
+++ b/src/components/note/noteCreate/EmbedPreview.tsx
@@ -78,7 +78,7 @@ export default function EmbedPreview({
       <button type="button" onClick={onClose}>
         <Icon
           icon={faClose}
-          className="hover:bg-gsbk focus:bg-gsbk active:bg-gsbk absolute right-4 top-4 rounded-full bg-gs600 text-gs00 transition-colors"
+          className="absolute right-4 top-4 rounded-full bg-gs600 text-gs00 transition-colors hover:bg-gsBk focus:bg-gsBk active:bg-gsBk"
         />
       </button>
     </section>

--- a/src/components/note/noteCreate/NoteContentEditor.tsx
+++ b/src/components/note/noteCreate/NoteContentEditor.tsx
@@ -130,6 +130,7 @@ export default function NoteContentEditor({
               onChange={(content) => {
                 onChange(content === '<p><br></p>' ? '' : content);
                 updateTextLength();
+                trigger('content');
               }}
               placeholder="이 곳을 클릭해 노트 작성을 시작해주세요"
               className="text-gsBk"

--- a/src/components/note/noteCreate/NoteContentEditor.tsx
+++ b/src/components/note/noteCreate/NoteContentEditor.tsx
@@ -81,10 +81,10 @@ export default function NoteContentEditor({
       </span>
 
       {linkUrl && (
-        <section className="text-gsbk mb-4 flex h-auto w-full items-center rounded-full bg-gs100 px-2 py-1 text-16R">
+        <section className="mb-4 flex h-auto w-full items-center rounded-full bg-gs100 px-2 py-1 text-16R text-gsBk">
           <Icon
             icon={faLink}
-            className="mr-2 size-6 rounded-full bg-slate500 text-gs00"
+            className="mr-2 size-6 min-h-6 min-w-6 rounded-full bg-slate500 text-gs00"
           />
           <button
             type="button"

--- a/src/components/note/noteCreate/NoteContentEditor.tsx
+++ b/src/components/note/noteCreate/NoteContentEditor.tsx
@@ -76,7 +76,7 @@ export default function NoteContentEditor({
 
   return (
     <>
-      <span className="mb-2 mt-3 text-12M">
+      <span className="mb-2 mt-3 text-12M text-gs600">
         공백포함: {textLength}자 | 공백제외: {trimmedTextLength}자
       </span>
 
@@ -132,7 +132,7 @@ export default function NoteContentEditor({
                 updateTextLength();
               }}
               placeholder="이 곳을 클릭해 노트 작성을 시작해주세요"
-              className="text-black"
+              className="text-gs600"
             />
           )}
         />

--- a/src/components/note/noteCreate/NoteContentEditor.tsx
+++ b/src/components/note/noteCreate/NoteContentEditor.tsx
@@ -81,7 +81,7 @@ export default function NoteContentEditor({
       </span>
 
       {linkUrl && (
-        <section className="mb-4 flex h-auto w-full items-center rounded-full bg-gs100 px-2 py-1 text-16R text-gs800">
+        <section className="text-gsbk mb-4 flex h-auto w-full items-center rounded-full bg-gs100 px-2 py-1 text-16R">
           <Icon
             icon={faLink}
             className="mr-2 size-6 rounded-full bg-slate500 text-gs00"
@@ -132,7 +132,7 @@ export default function NoteContentEditor({
                 updateTextLength();
               }}
               placeholder="이 곳을 클릭해 노트 작성을 시작해주세요"
-              className="text-gs600"
+              className="text-gsBk"
             />
           )}
         />

--- a/src/components/note/noteCreate/NoteEditHeader.tsx
+++ b/src/components/note/noteCreate/NoteEditHeader.tsx
@@ -24,10 +24,10 @@ export default function NoteEditHeader({
   return (
     <div className="w-full items-center border-b-2 border-gs200 bg-gs50 px-4 py-2 xs:flex sm:min-w-[400px]">
       <button type="button" onClick={handleBack}>
-        <Icon icon={faArrowLeft} className="size-5 text-gs600" />
+        <Icon icon={faArrowLeft} className="size-5 text-gsBk" />
       </button>
       <div className="ml-2 flex w-full items-center justify-between">
-        <h2 className="text-14SB text-gs600 xs:text-16SB md:text-18SB">
+        <h2 className="text-14SB text-gsBk xs:text-16SB md:text-18SB">
           {isEditMode ? '노트 수정' : '노트 작성'}
         </h2>
         <div className="flex justify-end gap-2 xs:justify-normal">

--- a/src/components/note/noteCreate/NoteEditHeader.tsx
+++ b/src/components/note/noteCreate/NoteEditHeader.tsx
@@ -24,10 +24,10 @@ export default function NoteEditHeader({
   return (
     <div className="w-full items-center border-b-2 border-gs200 bg-gs50 px-4 py-2 xs:flex sm:min-w-[400px]">
       <button type="button" onClick={handleBack}>
-        <Icon icon={faArrowLeft} className="size-5" />
+        <Icon icon={faArrowLeft} className="size-5 text-gs600" />
       </button>
       <div className="ml-2 flex w-full items-center justify-between">
-        <h2 className="text-14SB xs:text-16SB md:text-18SB">
+        <h2 className="text-14SB text-gs600 xs:text-16SB md:text-18SB">
           {isEditMode ? '노트 수정' : '노트 작성'}
         </h2>
         <div className="flex justify-end gap-2 xs:justify-normal">

--- a/src/components/note/noteCreate/NoteEditor.tsx
+++ b/src/components/note/noteCreate/NoteEditor.tsx
@@ -259,7 +259,7 @@ export default function NoteEditor({
 
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="text-gsbk mx-auto flex size-full flex-1 flex-col overflow-auto break-keep rounded-2xl border-2 border-gs200 bg-gs00 md:min-w-[452px]"
+        className="mx-auto flex size-full flex-1 flex-col overflow-auto break-keep rounded-2xl border-2 border-gs200 bg-gs00 text-gsBk md:min-w-[452px]"
       >
         <div>
           <NoteEditHeader
@@ -317,12 +317,8 @@ export default function NoteEditor({
           )}
         </div>
 
-        <div className="text-gsbk mx-6 mb-6 flex h-full min-h-0 flex-col">
-          <NoteTitle
-            control={control}
-            errors={errors}
-            color={goalQuery?.data?.todo?.color}
-          />
+        <div className="mx-6 mb-6 flex h-full min-h-0 flex-col text-gsBk">
+          <NoteTitle control={control} errors={errors} />
           <NoteContentEditor
             control={control}
             errors={errors}

--- a/src/components/note/noteCreate/NoteEditor.tsx
+++ b/src/components/note/noteCreate/NoteEditor.tsx
@@ -245,6 +245,10 @@ export default function NoteEditor({
     if (!linkUrl) setEmbedVisible(false);
   }, [linkUrl]);
 
+  const getTodoColorStyle = (color: string | undefined) => {
+    return color === 'default' ? { color: 'var(--slate500)' } : {};
+  };
+
   return (
     <div className="flex size-full flex-col md:flex-row">
       <EmbedPreview
@@ -255,7 +259,7 @@ export default function NoteEditor({
 
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="mx-auto flex size-full flex-1 flex-col overflow-auto break-keep rounded-2xl border-2 border-gs200 bg-gs00 text-gs900 md:min-w-[452px]"
+        className="text-gsbk mx-auto flex size-full flex-1 flex-col overflow-auto break-keep rounded-2xl border-2 border-gs200 bg-gs00 md:min-w-[452px]"
       >
         <div>
           <NoteEditHeader
@@ -288,13 +292,9 @@ export default function NoteEditor({
                       'size-4 rounded-lg text-lg',
                       `text-${goalQuery?.data.todo.color}`,
                     )}
-                    style={
-                      goalQuery?.data.todo.color === 'default'
-                        ? { color: 'var(--slate500)' }
-                        : {}
-                    }
+                    style={getTodoColorStyle(goalQuery?.data.todo.color)}
                   />
-                  <h3 className="w-[calc(100%-40px)] break-words text-16M text-gs600">
+                  <h3 className="w-[calc(100%-40px)] break-words text-16M text-gsBk">
                     {goalQuery.data?.todo.title}
                   </h3>
                 </section>
@@ -317,8 +317,12 @@ export default function NoteEditor({
           )}
         </div>
 
-        <div className="mx-6 mb-6 flex h-full min-h-0 flex-col text-gs800">
-          <NoteTitle control={control} errors={errors} />
+        <div className="text-gsbk mx-6 mb-6 flex h-full min-h-0 flex-col">
+          <NoteTitle
+            control={control}
+            errors={errors}
+            color={goalQuery?.data?.todo?.color}
+          />
           <NoteContentEditor
             control={control}
             errors={errors}

--- a/src/components/note/noteCreate/NoteEditor.tsx
+++ b/src/components/note/noteCreate/NoteEditor.tsx
@@ -288,8 +288,13 @@ export default function NoteEditor({
                       'size-4 rounded-lg text-lg',
                       `text-${goalQuery?.data.todo.color}`,
                     )}
+                    style={
+                      goalQuery?.data.todo.color === 'default'
+                        ? { color: 'var(--slate500)' }
+                        : {}
+                    }
                   />
-                  <h3 className="w-[calc(100%-40px)] break-words text-16M text-gs800">
+                  <h3 className="w-[calc(100%-40px)] break-words text-16M text-gs600">
                     {goalQuery.data?.todo.title}
                   </h3>
                 </section>
@@ -297,7 +302,7 @@ export default function NoteEditor({
               {/* 할 일 제목 */}
               <article
                 className={cn(
-                  'mx-6 mb-4 flex items-center gap-2 text-gs700',
+                  'mx-6 mb-4 flex items-center gap-2 text-gs600',
                   !goalQuery.data?.todo.title && 'mt-4',
                 )}
               >

--- a/src/components/note/noteCreate/NoteTitle.tsx
+++ b/src/components/note/noteCreate/NoteTitle.tsx
@@ -13,13 +13,15 @@ export default function NoteTitle({ control, errors }: NoteFormControlProps) {
             <>
               <input
                 placeholder="노트의 제목을 입력해주세요"
-                className="border-top border-bottom w-full rounded-none bg-gs00 pl-0 outline-none focus:border-gs200"
+                className="border-top border-bottom w-full rounded-none bg-gs00 pl-0 text-gs600 outline-none focus:border-gs200"
                 onChange={(e) => onChange(e.target.value)}
                 value={value}
                 maxLength={30}
               />
               <div className="flex px-1 py-[2px] text-xs font-medium">
-                <span className="text-error">{value ? value?.length : 0}</span>
+                <span className="text-error text-gs600">
+                  {value ? value?.length : 0}
+                </span>
                 <span className="text-blue-500">/30</span>
               </div>
             </>

--- a/src/components/note/noteCreate/NoteTitle.tsx
+++ b/src/components/note/noteCreate/NoteTitle.tsx
@@ -2,7 +2,14 @@ import { Controller } from 'react-hook-form';
 import ErrorMessage from '../../auth/ErrorMessage';
 import { NoteFormControlProps } from '@/types/note';
 
-export default function NoteTitle({ control, errors }: NoteFormControlProps) {
+export default function NoteTitle({
+  control,
+  errors,
+  color,
+}: NoteFormControlProps) {
+  const getColor = (col: string | undefined) => {
+    return col === 'default' ? {} : { color: col };
+  };
   return (
     <>
       <div className="flex items-center justify-between border-y border-gs200 py-3">
@@ -13,7 +20,7 @@ export default function NoteTitle({ control, errors }: NoteFormControlProps) {
             <>
               <input
                 placeholder="노트의 제목을 입력해주세요"
-                className="border-top border-bottom w-full rounded-none bg-gs00 pl-0 text-gs600 outline-none focus:border-gs200"
+                className="border-top border-bottom w-full rounded-none bg-gs00 pl-0 text-gsBk outline-none focus:border-gs200"
                 onChange={(e) => onChange(e.target.value)}
                 value={value}
                 maxLength={30}
@@ -22,7 +29,9 @@ export default function NoteTitle({ control, errors }: NoteFormControlProps) {
                 <span className="text-error text-gs600">
                   {value ? value?.length : 0}
                 </span>
-                <span className="text-blue-500">/30</span>
+                <span className={`text-${color}`} style={getColor(color)}>
+                  /30
+                </span>
               </div>
             </>
           )}

--- a/src/components/note/noteCreate/NoteTitle.tsx
+++ b/src/components/note/noteCreate/NoteTitle.tsx
@@ -2,14 +2,7 @@ import { Controller } from 'react-hook-form';
 import ErrorMessage from '../../auth/ErrorMessage';
 import { NoteFormControlProps } from '@/types/note';
 
-export default function NoteTitle({
-  control,
-  errors,
-  color,
-}: NoteFormControlProps) {
-  const getColor = (col: string | undefined) => {
-    return col === 'default' ? { color: `var(--slate500)` } : { color: col };
-  };
+export default function NoteTitle({ control, errors }: NoteFormControlProps) {
   return (
     <>
       <div className="flex items-center justify-between border-y border-gs200 py-3">
@@ -29,14 +22,7 @@ export default function NoteTitle({
                 <span className="text-error text-gs600">
                   {value ? value?.length : 0}
                 </span>
-                <span
-                  className={
-                    color && color !== 'default' ? `text-${color}` : 'text-gsBk'
-                  }
-                  style={getColor(color)}
-                >
-                  /30
-                </span>
+                <span className="text-slate500">/30</span>
               </div>
             </>
           )}

--- a/src/components/note/noteCreate/NoteTitle.tsx
+++ b/src/components/note/noteCreate/NoteTitle.tsx
@@ -8,7 +8,7 @@ export default function NoteTitle({
   color,
 }: NoteFormControlProps) {
   const getColor = (col: string | undefined) => {
-    return col === 'default' ? {} : { color: col };
+    return col === 'default' ? { color: `var(--slate500)` } : { color: col };
   };
   return (
     <>
@@ -29,7 +29,12 @@ export default function NoteTitle({
                 <span className="text-error text-gs600">
                   {value ? value?.length : 0}
                 </span>
-                <span className={`text-${color}`} style={getColor(color)}>
+                <span
+                  className={
+                    color && color !== 'default' ? `text-${color}` : 'text-gsBk'
+                  }
+                  style={getColor(color)}
+                >
                   /30
                 </span>
               </div>

--- a/src/components/note/noteCreate/NoteTitlesSkeleton.tsx
+++ b/src/components/note/noteCreate/NoteTitlesSkeleton.tsx
@@ -4,7 +4,7 @@ export default function NoteTitlesSkeleton() {
       <section className="mt-2 flex size-full items-center gap-2">
         <div className="h-6 w-full animate-pulse bg-gs100" />
       </section>
-      <article className="mb-2 flex size-full items-center gap-2 text-gs700">
+      <article className="mb-2 flex size-full items-center gap-2 text-gs600">
         <div className="h-6 w-full animate-pulse bg-gs100" />
       </article>
     </div>

--- a/src/styles/textEditor.css
+++ b/src/styles/textEditor.css
@@ -23,17 +23,37 @@
 }
 
 .ql-toolbar.ql-snow {
-  @apply z-10 w-full min-w-[400px] max-w-[752px] rounded-full border-gs200 bg-gs00;
+  @apply z-10 flex w-full min-w-[235px] max-w-[752px] flex-wrap rounded-full border-gs200 bg-gs00;
   @apply absolute bottom-3 left-0 md:left-[unset];
   box-shadow: 0px 1px 2px 0px #0000000d;
 }
 
+[data-dark='true'] .ql-toolbar.ql-snow .ql-stroke {
+  @apply !stroke-gsBk;
+}
+
+[data-dark='true'] .ql-toolbar.ql-snow .ql-fill {
+  @apply !fill-gsBk;
+}
+
+/* 시스템 다크 모드 */
+@media (prefers-color-scheme: dark) {
+  .ql-toolbar.ql-snow .ql-stroke {
+    @apply !stroke-gsBk;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .ql-toolbar.ql-snow .ql-fill {
+    @apply !fill-gsBk;
+  }
+}
+
 .ql-toolbar.ql-snow .ql-formats {
-  @apply mr-4;
+  @apply mr-0 sm:mr-3;
 }
 
 .ql-toolbar.ql-snow .ql-formats:last-child {
-  @apply absolute right-2 mr-0;
+  @apply absolute right-0 rounded-full bg-gs200;
 }
 
 .ql-snow.ql-toolbar:after {

--- a/src/types/note.d.ts
+++ b/src/types/note.d.ts
@@ -44,7 +44,6 @@ export interface NoteFormControlProps {
   }>;
   setEmbedVisible?: (val: boolean) => void;
   checkEmbedUrl?: () => void;
-  color?: string;
 }
 
 export interface NoteDetail {

--- a/src/types/note.d.ts
+++ b/src/types/note.d.ts
@@ -44,6 +44,7 @@ export interface NoteFormControlProps {
   }>;
   setEmbedVisible?: (val: boolean) => void;
   checkEmbedUrl?: () => void;
+  color?: string;
 }
 
 export interface NoteDetail {


### PR DESCRIPTION
## 개요 🔎

## 작업내용 📝

노트 생성 페이지 - 다크모드일 때 텍스트 색 수정, default 목표일 때 색상 가져옴 수정

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 노트 작성 시 할 일 항목에 대해 동적 색상 적용이 이루어져, 시각적인 구분이 강화되었습니다.

- **스타일**
  - 텍스트, 아이콘, 버튼 등 다양한 UI 요소의 색상과 간격이 개선되었습니다.
  - 다크 모드 및 상호작용(hover, focus, active) 상태에서의 배경 효과가 업데이트되어 전반적인 편집 환경의 가독성과 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->